### PR TITLE
Client show server error messages in UI

### DIFF
--- a/budget-binder-multiplatform-app/src/commonMain/kotlin/de/hsfl/budgetBinder/data/client/Client.kt
+++ b/budget-binder-multiplatform-app/src/commonMain/kotlin/de/hsfl/budgetBinder/data/client/Client.kt
@@ -11,7 +11,6 @@ import io.ktor.client.plugins.cookies.*
 import io.ktor.client.plugins.logging.*
 import io.ktor.client.request.*
 import io.ktor.client.request.forms.*
-import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.ktor.serialization.kotlinx.json.*
 
@@ -59,17 +58,12 @@ class Client : ApiClient {
     }
 
     override suspend fun login(email: String, password: String): APIResponse<AuthToken> {
-        val response: HttpResponse = client.submitForm(
+        return client.submitForm(
             url = "/login", formParameters = Parameters.build {
                 append("username", email)
                 append("password", password)
             }, encodeInQuery = false
-        )
-
-        return when (response.status) {
-            HttpStatusCode.Unauthorized -> APIResponse(ErrorModel("Username or Password incorrect"))
-            else -> response.body()
-        }
+        ).body()
     }
 
     override suspend fun register(

--- a/budget-binder-multiplatform-app/src/commonMain/kotlin/de/hsfl/budgetBinder/data/client/Client.kt
+++ b/budget-binder-multiplatform-app/src/commonMain/kotlin/de/hsfl/budgetBinder/data/client/Client.kt
@@ -11,6 +11,7 @@ import io.ktor.client.plugins.cookies.*
 import io.ktor.client.plugins.logging.*
 import io.ktor.client.request.*
 import io.ktor.client.request.forms.*
+import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.ktor.serialization.kotlinx.json.*
 
@@ -58,12 +59,17 @@ class Client : ApiClient {
     }
 
     override suspend fun login(email: String, password: String): APIResponse<AuthToken> {
-        return client.submitForm(
+        val response: HttpResponse = client.submitForm(
             url = "/login", formParameters = Parameters.build {
                 append("username", email)
                 append("password", password)
             }, encodeInQuery = false
-        ).body()
+        )
+
+        return when (response.status) {
+            HttpStatusCode.Unauthorized -> APIResponse(ErrorModel("Username or Password incorrect"))
+            else -> response.body()
+        }
     }
 
     override suspend fun register(

--- a/budget-binder-multiplatform-app/src/commonMain/kotlin/de/hsfl/budgetBinder/data/repository/AuthRepositoryImpl.kt
+++ b/budget-binder-multiplatform-app/src/commonMain/kotlin/de/hsfl/budgetBinder/data/repository/AuthRepositoryImpl.kt
@@ -4,7 +4,7 @@ import de.hsfl.budgetBinder.common.*
 import de.hsfl.budgetBinder.data.client.Client
 import de.hsfl.budgetBinder.domain.repository.AuthRepository
 
-class AuthRepositoryImplementation(
+class AuthRepositoryImpl(
     private val client: Client
 ) : AuthRepository {
     override suspend fun authorize(email: String, password: String): APIResponse<AuthToken> {

--- a/budget-binder-multiplatform-app/src/commonMain/kotlin/de/hsfl/budgetBinder/data/repository/UserRepositoryImpl.kt
+++ b/budget-binder-multiplatform-app/src/commonMain/kotlin/de/hsfl/budgetBinder/data/repository/UserRepositoryImpl.kt
@@ -5,15 +5,10 @@ import de.hsfl.budgetBinder.common.User
 import de.hsfl.budgetBinder.data.client.Client
 import de.hsfl.budgetBinder.domain.repository.UserRepository
 
-class UserRepositoryImplementation(
+class UserRepositoryImpl(
     private val client: Client
 ): UserRepository {
     override suspend fun getMyUser(): APIResponse<User> {
         return client.getMyUser()
     }
-
-    override suspend fun getUserById(userId: Int): APIResponse<User> {
-        TODO("Not yet implemented")
-    }
-
 }

--- a/budget-binder-multiplatform-app/src/commonMain/kotlin/de/hsfl/budgetBinder/domain/repository/UserRepository.kt
+++ b/budget-binder-multiplatform-app/src/commonMain/kotlin/de/hsfl/budgetBinder/domain/repository/UserRepository.kt
@@ -5,5 +5,4 @@ import de.hsfl.budgetBinder.common.User
 
 interface UserRepository {
     suspend fun getMyUser(): APIResponse<User>
-    suspend fun getUserById(userId: Int): APIResponse<User>
 }

--- a/budget-binder-multiplatform-app/src/commonMain/kotlin/de/hsfl/budgetBinder/domain/use_case/auth_user/LoginUseCase.kt
+++ b/budget-binder-multiplatform-app/src/commonMain/kotlin/de/hsfl/budgetBinder/domain/use_case/auth_user/LoginUseCase.kt
@@ -13,9 +13,11 @@ class LoginUseCase(
     operator fun invoke(email: String, password: String): Flow<DataResponse<AuthToken>> = flow {
         try {
             emit(DataResponse.Loading())
-            repository.authorize(email, password).data?.let {
-                emit(DataResponse.Success(it))
-            } ?: emit(DataResponse.Error("No Data response from Server"))
+            repository.authorize(email, password).let { response ->
+                response.data?.let {
+                    emit(DataResponse.Success(it))
+                } ?: emit(DataResponse.Error(response.error!!.message))
+            }
         } catch (e: IOException) {
             e.printStackTrace()
             emit(DataResponse.Error("Couldn't reach the server"))

--- a/budget-binder-multiplatform-app/src/commonMain/kotlin/de/hsfl/budgetBinder/domain/use_case/auth_user/LoginUseCase.kt
+++ b/budget-binder-multiplatform-app/src/commonMain/kotlin/de/hsfl/budgetBinder/domain/use_case/auth_user/LoginUseCase.kt
@@ -16,7 +16,8 @@ class LoginUseCase(
             repository.authorize(email, password).let { response ->
                 response.data?.let {
                     emit(DataResponse.Success(it))
-                } ?: emit(DataResponse.Error(response.error!!.message))
+                } ?: emit(DataResponse.Error("Username or Password incorrect"))
+                // Eigentlich response.error!!.message, aber status 401 kommt ohne body
             }
         } catch (e: IOException) {
             e.printStackTrace()

--- a/budget-binder-multiplatform-app/src/commonMain/kotlin/de/hsfl/budgetBinder/domain/use_case/auth_user/LoginUseCase.kt
+++ b/budget-binder-multiplatform-app/src/commonMain/kotlin/de/hsfl/budgetBinder/domain/use_case/auth_user/LoginUseCase.kt
@@ -16,8 +16,7 @@ class LoginUseCase(
             repository.authorize(email, password).let { response ->
                 response.data?.let {
                     emit(DataResponse.Success(it))
-                } ?: emit(DataResponse.Error("Username or Password incorrect"))
-                // Eigentlich response.error!!.message, aber status 401 kommt ohne body
+                } ?: emit(DataResponse.Error(response.error!!.message))
             }
         } catch (e: IOException) {
             e.printStackTrace()

--- a/budget-binder-multiplatform-app/src/commonMain/kotlin/de/hsfl/budgetBinder/domain/use_case/auth_user/LogoutUseCase.kt
+++ b/budget-binder-multiplatform-app/src/commonMain/kotlin/de/hsfl/budgetBinder/domain/use_case/auth_user/LogoutUseCase.kt
@@ -14,6 +14,7 @@ class LogoutUseCase(
             emit(DataResponse.Loading())
             repository.logout(onAllDevices)
             emit(DataResponse.Success(true))
+            // TODO: Handle Server Error
         } catch (e: IOException) {
             e.printStackTrace()
             emit(DataResponse.Error("Couldn't reach the server"))

--- a/budget-binder-multiplatform-app/src/commonMain/kotlin/de/hsfl/budgetBinder/domain/use_case/auth_user/RegisterUseCase.kt
+++ b/budget-binder-multiplatform-app/src/commonMain/kotlin/de/hsfl/budgetBinder/domain/use_case/auth_user/RegisterUseCase.kt
@@ -12,9 +12,11 @@ class RegisterUseCase(
     operator fun invoke(firstName: String, lastName: String, email: String, password: String): Flow<DataResponse<User>> = flow {
         try {
             emit(DataResponse.Loading())
-            repository.register(firstName, lastName, email, password).data?.let {
-                emit(DataResponse.Success(it))
-            } ?: emit(DataResponse.Error("No Data response from Server"))
+            repository.register(firstName, lastName, email, password).let { response ->
+                response.data?.let { 
+                    emit(DataResponse.Success(it))
+                } ?: emit(DataResponse.Error(response.error!!.message))
+            }
         } catch (e: IOException) {
             e.printStackTrace()
             emit(DataResponse.Error("Couldn't reach the server"))

--- a/budget-binder-multiplatform-app/src/commonMain/kotlin/de/hsfl/budgetBinder/domain/use_case/get_user/UserUseCase.kt
+++ b/budget-binder-multiplatform-app/src/commonMain/kotlin/de/hsfl/budgetBinder/domain/use_case/get_user/UserUseCase.kt
@@ -13,8 +13,10 @@ class UserUseCase(
     operator fun invoke(): Flow<DataResponse<User>> = flow {
         try {
             emit(DataResponse.Loading())
-            repository.getMyUser().data?.let {
-                emit(DataResponse.Success(it))
+            repository.getMyUser().let { response ->
+                response.data?.let {
+                    emit(DataResponse.Success(it))
+                } ?: emit(DataResponse.Error(response.error!!.message))
             }
         } catch (e: IOException) {
             emit(DataResponse.Error("Couldn't reach the server"))

--- a/budget-binder-multiplatform-app/src/commonMain/kotlin/de/hsfl/budgetBinder/presentation/LoginViewModel.kt
+++ b/budget-binder-multiplatform-app/src/commonMain/kotlin/de/hsfl/budgetBinder/presentation/LoginViewModel.kt
@@ -24,7 +24,8 @@ class LoginViewModel(
                     _state.value = UiState.Success(response.data)
                 }
                 is DataResponse.Error -> {
-                    _state.value = UiState.Error(response.message!!)
+                    // Eigentlich response.error!!.message, aber status 401 kommt ohne body
+                    _state.value = UiState.Error("Username or Password incorrect")
                 }
                 is DataResponse.Loading -> {
                     _state.value = UiState.Loading

--- a/budget-binder-multiplatform-app/src/commonMain/kotlin/de/hsfl/budgetBinder/presentation/LoginViewModel.kt
+++ b/budget-binder-multiplatform-app/src/commonMain/kotlin/de/hsfl/budgetBinder/presentation/LoginViewModel.kt
@@ -24,8 +24,7 @@ class LoginViewModel(
                     _state.value = UiState.Success(response.data)
                 }
                 is DataResponse.Error -> {
-                    // Eigentlich response.error!!.message, aber status 401 kommt ohne body
-                    _state.value = UiState.Error("Username or Password incorrect")
+                    _state.value = UiState.Error(response.message!!)
                 }
                 is DataResponse.Loading -> {
                     _state.value = UiState.Loading

--- a/budget-binder-multiplatform-app/src/commonMain/kotlin/de/hsfl/budgetBinder/presentation/LoginViewModel.kt
+++ b/budget-binder-multiplatform-app/src/commonMain/kotlin/de/hsfl/budgetBinder/presentation/LoginViewModel.kt
@@ -18,13 +18,13 @@ class LoginViewModel(
     val state: StateFlow<UiState> = _state
 
     fun auth(email: String, password: String) {
-        authUseCase(email, password).onEach { auth ->
-            when (auth) {
+        authUseCase(email, password).onEach { response ->
+            when (response) {
                 is DataResponse.Success -> {
-                    _state.value = UiState.Success(true)
+                    _state.value = UiState.Success(response.data)
                 }
                 is DataResponse.Error -> {
-                    _state.value = UiState.Error("Username or Password incorrect")
+                    _state.value = UiState.Error(response.message!!)
                 }
                 is DataResponse.Loading -> {
                     _state.value = UiState.Loading

--- a/budget-binder-multiplatform-app/src/jvmMain/kotlin/de/hsfl/budgetBinder/compose/Root.kt
+++ b/budget-binder-multiplatform-app/src/jvmMain/kotlin/de/hsfl/budgetBinder/compose/Root.kt
@@ -7,8 +7,8 @@ import androidx.compose.material.icons.filled.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.graphics.Color
 import de.hsfl.budgetBinder.data.client.Client
-import de.hsfl.budgetBinder.data.repository.AuthRepositoryImplementation
-import de.hsfl.budgetBinder.data.repository.UserRepositoryImplementation
+import de.hsfl.budgetBinder.data.repository.AuthRepositoryImpl
+import de.hsfl.budgetBinder.data.repository.UserRepositoryImpl
 import de.hsfl.budgetBinder.domain.repository.AuthRepository
 import de.hsfl.budgetBinder.domain.repository.UserRepository
 import de.hsfl.budgetBinder.domain.use_case.auth_user.LoginUseCase
@@ -24,8 +24,8 @@ import org.kodein.di.instance
 val di = DI {
     bindSingleton { Client() }
 
-    bindSingleton<AuthRepository> { AuthRepositoryImplementation(instance()) }
-    bindSingleton<UserRepository> { UserRepositoryImplementation(instance()) }
+    bindSingleton<AuthRepository> { AuthRepositoryImpl(instance()) }
+    bindSingleton<UserRepository> { UserRepositoryImpl(instance()) }
 
     bindSingleton { RegisterUseCase(instance()) }
     bindSingleton { LoginUseCase(instance()) }

--- a/budget-binder-multiplatform-app/src/jvmMain/kotlin/de/hsfl/budgetBinder/compose/Root.kt
+++ b/budget-binder-multiplatform-app/src/jvmMain/kotlin/de/hsfl/budgetBinder/compose/Root.kt
@@ -35,7 +35,7 @@ val di = DI {
 
 @Composable
 fun App() = withDI(di) {
-    val screenState = remember { mutableStateOf<Screen>(Screen.Register) }
+    val screenState = remember { mutableStateOf<Screen>(Screen.Login) }
     val darkTheme = remember { mutableStateOf(false) }
     MaterialTheme(
         colors = if (darkTheme.value) darkColors() else lightColors()


### PR DESCRIPTION
# Was wurde umgesetzt?
Wenn eine Fehlermeldung vom Backend kommt, wird diese Fehlerbeschreibung in der UI angezeigt. Wenn `data = null` gilt immer `error != null`. So lässt sich folgende Logik umsetzten.
```kotlin
repository.[function(...)].let { response ->
    response.data?.let { 
        emit(DataResponse.Success(it))
    } ?: emit(DataResponse.Error(response.error!!.message))
}
```

- Aktuell nur mit Fehler von `/register` möglich
- `/login` Error mit Status 401 wird ohne Body gesendet, daher wird die Fehlermeldung im Client erzeugt 
- Da `/logout` noch keine Funktion hat, wurde die Implementieren des Fehlers mit `TODO` markiert
