### PR TITLE
Settings Screen - Implement Snackbar and more

### DIFF
--- a/budget-binder-multiplatform-app/src/jvmMain/kotlin/de/hsfl/budgetBinder/prototype/PrototypeRoot.kt
+++ b/budget-binder-multiplatform-app/src/jvmMain/kotlin/de/hsfl/budgetBinder/prototype/PrototypeRoot.kt
@@ -2,23 +2,26 @@ package de.hsfl.budgetBinder.prototype
 
 import androidx.compose.material.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import de.hsfl.budgetBinder.prototype.StateManager.darkMode
 import de.hsfl.budgetBinder.prototype.StateManager.drawerState
+import de.hsfl.budgetBinder.prototype.StateManager.scaffoldState
+import de.hsfl.budgetBinder.prototype.StateManager.snackbarHostState
 import de.hsfl.budgetBinder.prototype.navigation.DrawerContent
 import kotlinx.coroutines.launch
 
 // Root Component to handle View's
 @Composable
 fun Prototype() {
-    val scaffoldState = rememberScaffoldState()
+    val scaffold = remember { scaffoldState }
     val scope = rememberCoroutineScope()
     MaterialTheme(
         colors = if (darkMode.value) darkColors() else lightColors()
     ) {
         // Scaffold to handle AppBar, Floating Buttons, Snackbar and Co.
         Scaffold(
-            scaffoldState = scaffoldState,
+            scaffoldState = scaffold,
             topBar = {
                 PrototypeAppBar {
                     scope.launch {
@@ -27,7 +30,6 @@ fun Prototype() {
                     }
                 }
             },
-            snackbarHost = {},
             floatingActionButton = {},
             floatingActionButtonPosition = FabPosition.End,
             isFloatingActionButtonDocked = false,

--- a/budget-binder-multiplatform-app/src/jvmMain/kotlin/de/hsfl/budgetBinder/prototype/StateManager.kt
+++ b/budget-binder-multiplatform-app/src/jvmMain/kotlin/de/hsfl/budgetBinder/prototype/StateManager.kt
@@ -1,12 +1,15 @@
 package de.hsfl.budgetBinder.prototype
 
-import androidx.compose.material.DrawerState
-import androidx.compose.material.DrawerValue
+import androidx.compose.material.*
 import androidx.compose.runtime.mutableStateOf
 
 object StateManager {
     val screenState = mutableStateOf<PrototypeScreen>(PrototypeScreen.Welcome)
     val drawerState = DrawerState(DrawerValue.Closed)
+    val snackbarHostState = SnackbarHostState()
+    val scaffoldState = ScaffoldState(drawerState = drawerState, snackbarHostState = snackbarHostState)
+
+    // Settings
     val darkMode = mutableStateOf(false)
     val userState = mutableStateOf(User())
     val serverState = mutableStateOf(Server())

--- a/budget-binder-multiplatform-app/src/jvmMain/kotlin/de/hsfl/budgetBinder/prototype/screens/settings/Settings.kt
+++ b/budget-binder-multiplatform-app/src/jvmMain/kotlin/de/hsfl/budgetBinder/prototype/screens/settings/Settings.kt
@@ -19,7 +19,6 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import de.hsfl.budgetBinder.prototype.StateManager.darkMode
-import de.hsfl.budgetBinder.prototype.StateManager.scaffoldState
 import de.hsfl.budgetBinder.prototype.StateManager.serverState
 import de.hsfl.budgetBinder.prototype.StateManager.snackbarHostState
 import de.hsfl.budgetBinder.prototype.StateManager.userState
@@ -170,6 +169,7 @@ private fun UserSettings() {
                         email = emailState.value,
                         password = passwordState.value
                     )
+                    settingsScreenState.value = SettingsScreens.Menu
                     scope.launch {
                         snackbarHostState.showSnackbar(
                             message = "Update User Settings",
@@ -177,7 +177,6 @@ private fun UserSettings() {
                             duration = SnackbarDuration.Indefinite
                         )
                     }
-                    settingsScreenState.value = SettingsScreens.Menu
                 }) {
                     Text("Update")
                 }
@@ -191,12 +190,17 @@ private fun ServerSettings() {
     val serverUrlState = remember { mutableStateOf(serverState.value.serverUrl) }
     Column(modifier = Modifier.fillMaxSize().padding(16.dp), horizontalAlignment = Alignment.CenterHorizontally) {
         TextField(
-            modifier = Modifier.padding(16.dp).fillMaxWidth(),
+            modifier = Modifier.padding(top = 16.dp, start = 16.dp, end = 16.dp).fillMaxWidth(),
             value = serverUrlState.value,
             enabled = false,
             onValueChange = { serverUrlState.value = it },
             label = { Text("Server URL") },
             singleLine = true
+        )
+        Text(
+            modifier = Modifier.padding(bottom = 16.dp),
+            text = "You can't change the Server URL when you are logged in",
+            style = MaterialTheme.typography.caption
         )
         Button(onClick = { settingsScreenState.value = SettingsScreens.Menu }) {
             Text("Back")

--- a/budget-binder-multiplatform-app/src/jvmMain/kotlin/de/hsfl/budgetBinder/prototype/screens/settings/Settings.kt
+++ b/budget-binder-multiplatform-app/src/jvmMain/kotlin/de/hsfl/budgetBinder/prototype/screens/settings/Settings.kt
@@ -25,7 +25,7 @@ import de.hsfl.budgetBinder.prototype.StateManager.userState
 import de.hsfl.budgetBinder.prototype.User
 import kotlinx.coroutines.launch
 
-val settingsScreenState = mutableStateOf<SettingsScreens>(SettingsScreens.Menu)
+private val settingsScreenState = mutableStateOf<SettingsScreens>(SettingsScreens.Menu)
 
 @Composable
 fun SettingsComponent() {
@@ -96,6 +96,7 @@ private fun MenuView(
     Column(modifier = modifier) {
         Divider()
         ListItem(text = { Text("Dark Mode") },
+            modifier = Modifier.clickable(onClick = { darkMode.value = !darkMode.value }),
             icon = { Icon(Icons.Filled.Build, contentDescription = null) },
             trailing = {
                 Switch(modifier = Modifier.padding(start = 8.dp),

--- a/budget-binder-multiplatform-app/src/jvmMain/kotlin/de/hsfl/budgetBinder/prototype/screens/settings/Settings.kt
+++ b/budget-binder-multiplatform-app/src/jvmMain/kotlin/de/hsfl/budgetBinder/prototype/screens/settings/Settings.kt
@@ -10,6 +10,7 @@ import androidx.compose.material.icons.filled.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
@@ -18,9 +19,12 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import de.hsfl.budgetBinder.prototype.StateManager.darkMode
+import de.hsfl.budgetBinder.prototype.StateManager.scaffoldState
 import de.hsfl.budgetBinder.prototype.StateManager.serverState
+import de.hsfl.budgetBinder.prototype.StateManager.snackbarHostState
 import de.hsfl.budgetBinder.prototype.StateManager.userState
 import de.hsfl.budgetBinder.prototype.User
+import kotlinx.coroutines.launch
 
 val settingsScreenState = mutableStateOf<SettingsScreens>(SettingsScreens.Menu)
 
@@ -114,6 +118,7 @@ private fun MenuView(
 
 @Composable
 private fun UserSettings() {
+    val scope = rememberCoroutineScope()
     val firstNameState = remember { mutableStateOf(userState.value.firstName) }
     val lastNameState = remember { mutableStateOf(userState.value.lastName) }
     val emailState = remember { mutableStateOf(userState.value.email) }
@@ -158,12 +163,20 @@ private fun UserSettings() {
                     Text("Back")
                 }
                 Button(modifier = Modifier.weight(1F).padding(16.dp), onClick = {
+
                     userState.value = User(
                         firstName = firstNameState.value,
                         lastName = lastNameState.value,
                         email = emailState.value,
                         password = passwordState.value
                     )
+                    scope.launch {
+                        snackbarHostState.showSnackbar(
+                            message = "Update User Settings",
+                            actionLabel = "Dismiss",
+                            duration = SnackbarDuration.Indefinite
+                        )
+                    }
                     settingsScreenState.value = SettingsScreens.Menu
                 }) {
                     Text("Update")


### PR DESCRIPTION
# Was wurde umgesetzt
Dieser PR baut auf dem PR #55 auf. Hier wurde eine Snackbar Anzeige beim Update der User Settings implementiert, sowie eine Caption warum der User die Server URL nicht ändern darf und der DarkMode kann nun auch beim Klick auf das `ListItem` getoggelt werden, nicht nur über den Switch