### PR TITLE
100 cors entfernen

### DIFF
--- a/budget-binder-server/build.gradle.kts
+++ b/budget-binder-server/build.gradle.kts
@@ -19,14 +19,13 @@ application {
 
 repositories {
     mavenCentral()
-    maven("https://s01.oss.sonatype.org/content/repositories/snapshots/")
 }
 
 dependencies {
     implementation(project(":budget-binder-common"))
     implementation(kotlin("stdlib"))
 
-    val ktorVersion = "2.0.1"
+    val ktorVersion = "2.0.2"
     implementation("io.ktor:ktor-network-tls-certificates-jvm:$ktorVersion")
     implementation("io.ktor:ktor-server-core-jvm:$ktorVersion")
     implementation("io.ktor:ktor-server-auth-jvm:$ktorVersion")
@@ -43,9 +42,9 @@ dependencies {
     testImplementation("io.ktor:ktor-server-test-host-jvm:$ktorVersion")
     testImplementation("io.ktor:ktor-client-content-negotiation:$ktorVersion")
 
-    implementation("org.kodein.di:kodein-di-framework-ktor-server-jvm:8.0.0-ktor-2-SNAPSHOT")
+    implementation("org.kodein.di:kodein-di-framework-ktor-server-jvm:7.12.0")
 
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.1")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.2")
 
 
     implementation("ch.qos.logback:logback-classic:1.2.11")
@@ -57,12 +56,12 @@ dependencies {
     implementation("org.jetbrains.exposed:exposed-java-time:$exposedVersion")
     implementation("org.xerial:sqlite-jdbc:3.36.0.3")
     implementation("mysql:mysql-connector-java:8.0.29")
-    implementation("org.postgresql:postgresql:42.3.4")
+    implementation("org.postgresql:postgresql:42.3.6")
     implementation("org.mindrot:jbcrypt:0.4")
 
-    implementation("com.github.ajalt.clikt:clikt:3.4.2")
-    implementation("com.sksamuel.hoplite:hoplite-core:2.1.4")
-    implementation("com.sksamuel.hoplite:hoplite-yaml:2.1.4")
+    implementation("com.github.ajalt.clikt:clikt:3.5.0")
+    implementation("com.sksamuel.hoplite:hoplite-core:2.1.5")
+    implementation("com.sksamuel.hoplite:hoplite-yaml:2.1.5")
 
     testImplementation("org.jetbrains.kotlin:kotlin-test:1.6.21")
 }

--- a/budget-binder-server/build.gradle.kts
+++ b/budget-binder-server/build.gradle.kts
@@ -36,7 +36,6 @@ dependencies {
     implementation("io.ktor:ktor-server-netty-jvm:$ktorVersion")
     implementation("io.ktor:ktor-server-html-builder-jvm:$ktorVersion")
     implementation("io.ktor:ktor-server-status-pages:$ktorVersion")
-    implementation("io.ktor:ktor-server-cors:$ktorVersion")
     implementation("io.ktor:ktor-server-call-logging:$ktorVersion")
     implementation("io.ktor:ktor-server-content-negotiation:$ktorVersion")
     testImplementation("io.ktor:ktor-server-test-host-jvm:$ktorVersion")

--- a/budget-binder-server/data/config_sample.yaml
+++ b/budget-binder-server/data/config_sample.yaml
@@ -7,9 +7,6 @@ server:
     sslPort: 8443
     keyStorePassword: null
     keyStorePath: null
-    frontendAddresses:
-      - http://localhost:8080
-      - http://localhost:8081
     noForwardedHeaderSupport: false
 dataBase:
     dbType: SQLITE

--- a/budget-binder-server/src/main/kotlin/de/hsfl/budgetBinder/server/config/Config.kt
+++ b/budget-binder-server/src/main/kotlin/de/hsfl/budgetBinder/server/config/Config.kt
@@ -11,7 +11,6 @@ data class Config(val server: Server, val dataBase: DataBase, val jwt: JWT) {
         val sslPort: Int,
         val keyStorePassword: String,
         val keyStorePath: String,
-        val frontendAddresses: List<String>,
         val forwardedHeaderSupport: Boolean
     )
 

--- a/budget-binder-server/src/main/kotlin/de/hsfl/budgetBinder/server/config/ConfigIntermediate.kt
+++ b/budget-binder-server/src/main/kotlin/de/hsfl/budgetBinder/server/config/ConfigIntermediate.kt
@@ -56,11 +56,11 @@ data class ConfigIntermediate(val server: Server?, val dataBase: DataBase, val j
             dbPassword = ""
         } else {
             sqlitePath = ""
-            dbServerAddress = dataBase.serverAddress ?: throw Exception("No dbServerAddress specified")
-            dbServerPort = dataBase.serverPort ?: throw Exception("No dbServerPort specified")
-            dbName = dataBase.name ?: throw Exception("No dbDatabaseName specified")
-            dbUser = dataBase.user ?: throw Exception("No dbUser specified")
-            dbPassword = dataBase.password ?: throw Exception("No dbPassword specified")
+            dbServerAddress = dataBase.serverAddress ?: error("No dbServerAddress specified")
+            dbServerPort = dataBase.serverPort ?: error("No dbServerPort specified")
+            dbName = dataBase.name ?: error("No dbDatabaseName specified")
+            dbUser = dataBase.user ?: error("No dbUser specified")
+            dbPassword = dataBase.password ?: error("No dbPassword specified")
         }
 
         val dev = server?.dev ?: false
@@ -75,9 +75,9 @@ data class ConfigIntermediate(val server: Server?, val dataBase: DataBase, val j
         val keyStorePath: String
         if (ssl) {
             keyStorePassword = server?.keyStorePassword
-                ?: if (dev) "budget-binder-server" else throw Exception("No KeystorePassword provided")
+                ?: if (dev) "budget-binder-server" else error("No KeystorePassword provided")
             keyStorePath = server?.keyStorePath
-                ?: if (dev) "data/dev_keystore.jks" else throw Exception("No KeystorePath provided")
+                ?: if (dev) "data/dev_keystore.jks" else error("No KeystorePath provided")
         } else {
             keyStorePassword = ""
             keyStorePath = ""
@@ -142,7 +142,7 @@ private fun getConfigIntermediateFromEnv(): ConfigIntermediate {
         "SQLITE" -> Config.DBType.SQLITE
         "MYSQL" -> Config.DBType.MYSQL
         "POSTGRES" -> Config.DBType.POSTGRES
-        else -> throw Exception("No Database Type given")
+        else -> error("No Database Type given")
     }
 
     val dataBase = ConfigIntermediate.DataBase(
@@ -155,8 +155,8 @@ private fun getConfigIntermediateFromEnv(): ConfigIntermediate {
         System.getenv("DB_PASSWORD")
     )
 
-    val accessSecret = System.getenv("JWT_ACCESS_SECRET") ?: throw Exception("No AccessTokenSecret given")
-    val refreshSecret = System.getenv("JWT_REFRESH_SECRET") ?: throw Exception("No RefreshTokenSecret given")
+    val accessSecret = System.getenv("JWT_ACCESS_SECRET") ?: error("No AccessTokenSecret given")
+    val refreshSecret = System.getenv("JWT_REFRESH_SECRET") ?: error("No RefreshTokenSecret given")
 
     val jwt = ConfigIntermediate.JWT(
         accessSecret,

--- a/budget-binder-server/src/main/kotlin/de/hsfl/budgetBinder/server/config/ConfigIntermediate.kt
+++ b/budget-binder-server/src/main/kotlin/de/hsfl/budgetBinder/server/config/ConfigIntermediate.kt
@@ -5,7 +5,7 @@ import com.sksamuel.hoplite.addFileSource
 import com.sksamuel.hoplite.yaml.YamlPropertySource
 import java.io.File
 
-data class ConfigIntermediate(val server: Server, val dataBase: DataBase, val jwt: JWT) {
+data class ConfigIntermediate(val server: Server?, val dataBase: DataBase, val jwt: JWT) {
     data class Server(
         val dev: Boolean?,
         val ssl: Boolean?,
@@ -15,7 +15,6 @@ data class ConfigIntermediate(val server: Server, val dataBase: DataBase, val jw
         val sslPort: Int?,
         val keyStorePassword: String?,
         val keyStorePath: String?,
-        val frontendAddresses: List<String>?,
         val noForwardedHeaderSupport: Boolean?
     )
 
@@ -64,29 +63,27 @@ data class ConfigIntermediate(val server: Server, val dataBase: DataBase, val jw
             dbPassword = dataBase.password ?: throw Exception("No dbPassword specified")
         }
 
-        val dev = server.dev ?: false
-        val ssl = server.ssl ?: false
+        val dev = server?.dev ?: false
+        val ssl = server?.ssl ?: false
 
-        val host = server.host ?: "0.0.0.0"
-        val port = server.port ?: 8080
-        val sslHost = server.sslHost ?: "0.0.0.0"
-        val sslPort = server.sslPort ?: 8443
+        val host = server?.host ?: "0.0.0.0"
+        val port = server?.port ?: 8080
+        val sslHost = server?.sslHost ?: "0.0.0.0"
+        val sslPort = server?.sslPort ?: 8443
 
         val keyStorePassword: String
         val keyStorePath: String
         if (ssl) {
-            keyStorePassword = server.keyStorePassword
+            keyStorePassword = server?.keyStorePassword
                 ?: if (dev) "budget-binder-server" else throw Exception("No KeystorePassword provided")
-            keyStorePath = server.keyStorePath
+            keyStorePath = server?.keyStorePath
                 ?: if (dev) "data/dev_keystore.jks" else throw Exception("No KeystorePath provided")
         } else {
             keyStorePassword = ""
             keyStorePath = ""
         }
 
-        val frontendAddresses = server.frontendAddresses ?: emptyList()
-
-        val forwardedHeaderSupport = !(server.noForwardedHeaderSupport ?: false)
+        val forwardedHeaderSupport = !(server?.noForwardedHeaderSupport ?: false)
 
         val jwtAccessSecret = jwt.accessSecret
         val jwtRefreshSecret = jwt.refreshSecret
@@ -114,7 +111,6 @@ data class ConfigIntermediate(val server: Server, val dataBase: DataBase, val jw
                 sslPort,
                 keyStorePassword,
                 keyStorePath,
-                frontendAddresses,
                 forwardedHeaderSupport
             ), jwt = Config.JWT(
                 jwtAccessSecret,
@@ -139,7 +135,6 @@ private fun getConfigIntermediateFromEnv(): ConfigIntermediate {
         System.getenv("SSL_PORT")?.toIntOrNull(),
         System.getenv("KEYSTORE_PASSWORD"),
         System.getenv("KEYSTORE_PATH"),
-        System.getenv("FRONTEND_ADDRESSES")?.replace(" ", "")?.split(","),
         System.getenv("NO_FORWARDED_HEADER") != null
     )
 

--- a/budget-binder-server/src/main/kotlin/de/hsfl/budgetBinder/server/mainModule.kt
+++ b/budget-binder-server/src/main/kotlin/de/hsfl/budgetBinder/server/mainModule.kt
@@ -39,13 +39,9 @@ import org.slf4j.event.Level
 import java.sql.DriverManager
 
 fun Application.mainModule(config: Config) {
-    val url: String
-    val driver: String
-    when (config.dataBase.dbType) {
+    val url: String = when (config.dataBase.dbType) {
         Config.DBType.SQLITE -> {
-            url = "jdbc:sqlite:${config.dataBase.sqlitePath}"
-            driver = "org.sqlite.JDBC"
-
+            val url = "jdbc:sqlite:${config.dataBase.sqlitePath}"
             /*
             * The url is used in the tests to not create or alter the normal database.
             * the connection must be held because exposed closes the connection to the db
@@ -54,18 +50,13 @@ fun Application.mainModule(config: Config) {
             if (url == "jdbc:sqlite:file:test?mode=memory&cache=shared") {
                 DriverManager.getConnection(url)
             }
+            url
         }
-        Config.DBType.MYSQL -> {
-            url = "jdbc:mysql://${config.dataBase.serverAddress}:${config.dataBase.serverPort}/${config.dataBase.name}"
-            driver = "com.mysql.cj.jdbc.Driver"
-        }
-        Config.DBType.POSTGRES -> {
-            url = "jdbc:postgresql://${config.dataBase.serverAddress}:${config.dataBase.serverPort}/${config.dataBase.name}"
-            driver = "org.postgresql.Driver"
-        }
+        Config.DBType.MYSQL -> "jdbc:mysql://${config.dataBase.serverAddress}:${config.dataBase.serverPort}/${config.dataBase.name}"
+        Config.DBType.POSTGRES -> "jdbc:postgresql://${config.dataBase.serverAddress}:${config.dataBase.serverPort}/${config.dataBase.name}"
     }
 
-    Database.connect(url, driver, user = config.dataBase.user, password = config.dataBase.password)
+    Database.connect(url, user = config.dataBase.user, password = config.dataBase.password)
 
     transaction {
         SchemaUtils.create(Users, Categories, Entries)

--- a/budget-binder-server/src/main/kotlin/de/hsfl/budgetBinder/server/mainModule.kt
+++ b/budget-binder-server/src/main/kotlin/de/hsfl/budgetBinder/server/mainModule.kt
@@ -24,7 +24,6 @@ import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.plugins.callloging.CallLogging
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
-import io.ktor.server.plugins.cors.routing.*
 import io.ktor.server.plugins.forwardedheaders.*
 import io.ktor.server.plugins.statuspages.*
 import kotlinx.serialization.json.Json
@@ -83,22 +82,6 @@ fun Application.mainModule(config: Config) {
     install(CallLogging) {
         level = Level.INFO
         disableDefaultColors()
-    }
-
-    install(CORS) {
-        config.server.frontendAddresses.forEach {
-            val (scheme, hostName) = it.split("://")
-            allowHost(hostName, schemes = listOf(scheme))
-        }
-        allowCredentials = true
-        allowHeader(HttpHeaders.Authorization)
-        allowHeader(HttpHeaders.ContentType)
-        allowMethod(HttpMethod.Put)
-        allowMethod(HttpMethod.Options)
-        allowMethod(HttpMethod.Patch)
-        allowMethod(HttpMethod.Delete)
-        allowMethod(HttpMethod.Post)
-        allowNonSimpleContentTypes = true
     }
 
     if (config.server.forwardedHeaderSupport)

--- a/budget-binder-server/src/main/kotlin/de/hsfl/budgetBinder/server/services/JWTService.kt
+++ b/budget-binder-server/src/main/kotlin/de/hsfl/budgetBinder/server/services/JWTService.kt
@@ -78,7 +78,7 @@ class JWTService(private val config: Config) {
             path = "/refresh_token",
             httpOnly = true,
             secure = isHttps,
-            extensions = hashMapOf(CookieHeaderNames.SAMESITE to if (isHttps) CookieHeaderNames.SameSite.None.toString() else CookieHeaderNames.SameSite.Lax.toString())
+            extensions = hashMapOf(CookieHeaderNames.SAMESITE to CookieHeaderNames.SameSite.Strict.toString())
         )
     }
 }

--- a/budget-binder-server/src/test/kotlin/de/hsfl/budgetBinder/server/TestHelpers.kt
+++ b/budget-binder-server/src/test/kotlin/de/hsfl/budgetBinder/server/TestHelpers.kt
@@ -17,8 +17,6 @@ fun customTestApplication(block: suspend ApplicationTestBuilder.(client: HttpCli
             dataBase:
                 dbType: SQLITE
                 sqlitePath: file:test?mode=memory&cache=shared
-            server:
-                frontendAddresses: http://localhost:8081
             jwt:
                 accessSecret: testSecret
                 refreshSecret: testSecret2


### PR DESCRIPTION
Da der JS-Client nun vollständig über den Server selbst gehostet wird, benötigen wir CORS nicht mehr.

Dies hat zur Folge, dass keine anderen Web-Frontends mehr unser Backend nutzen können. Was auch so gewollt ist.