### PR TITLE
Change TopBar on Login and Register

### DIFF
--- a/budget-binder-multiplatform-app/src/androidMain/kotlin/de/hsfl/budgetBinder/compose/dialog/ServerUrlDialog.kt
+++ b/budget-binder-multiplatform-app/src/androidMain/kotlin/de/hsfl/budgetBinder/compose/dialog/ServerUrlDialog.kt
@@ -1,5 +1,6 @@
 package de.hsfl.budgetBinder.compose.dialog
 
+import androidx.compose.foundation.layout.Column
 import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Dns
@@ -17,11 +18,16 @@ actual fun ServerUrlDialog(
         AlertDialog(onDismissRequest = onDismiss,
             title = { Text(text = "Please Enter Server URL") },
             text = {
-                TextField(
-                    value = value,
-                    onValueChange = onValueChange,
-                    label = { Text("Server URL") },
-                    leadingIcon = { Icon(Icons.Filled.Dns, contentDescription = null) })
+                Column {
+                    TextField(
+                        value = value,
+                        onValueChange = onValueChange,
+                        label = { Text("Server URL") },
+                        leadingIcon = { Icon(Icons.Filled.Dns, contentDescription = null) },
+                        singleLine = true
+                    )
+                    Text("Please enter the server url from your own budget binder server here", style = MaterialTheme.typography.caption)
+                }
             },
             confirmButton = {
                 TextButton(onClick = onConfirm) {

--- a/budget-binder-multiplatform-app/src/commonMain/kotlin/de/hsfl/budgetBinder/di/DI.kt
+++ b/budget-binder-multiplatform-app/src/commonMain/kotlin/de/hsfl/budgetBinder/di/DI.kt
@@ -84,10 +84,11 @@ fun kodein(ktorEngine: HttpClientEngine) = DI {
     bindSingleton { StoreUserStateUseCase() }
     bindSingleton { StoreServerUrlUseCase() }
     bindSingleton { StoreDarkModeUseCase() }
+    bindSingleton { ToggleServerUrlDialogUseCase() }
     bindSingleton { EntryUseCases(instance(), instance(), instance(), instance(), instance(), instance()) }
     bindSingleton { CategoriesUseCases(instance(), instance(), instance(), instance(), instance(), instance()) }
     bindSingleton { SettingsUseCases(instance(), instance(), instance()) }
-    bindSingleton { AuthUseCases(instance(), instance(), instance(), instance(), instance(), instance()) }
+    bindSingleton { AuthUseCases(instance(), instance(), instance(), instance(), instance(), instance(), instance()) }
     bindSingleton { DashboardUseCases(instance(), instance(), instance(), instance()) }
     bindSingleton { DataFlowUseCases(instance(), instance(), instance()) }
 
@@ -110,5 +111,5 @@ fun kodein(ktorEngine: HttpClientEngine) = DI {
     bindSingleton { CategoryCreateViewModel(instance(), instance(), instance()) }
     bindSingleton { EntryViewModel(instance(), instance(), instance()) }
     bindSingleton { DashboardViewModel(instance(), instance(), instance()) }
-    bindSingleton { NavDrawerViewModel(instance(), instance(), instance()) }
+    bindSingleton { NavDrawerViewModel(instance(), instance(), instance(), instance()) }
 }

--- a/budget-binder-multiplatform-app/src/commonMain/kotlin/de/hsfl/budgetBinder/domain/usecase/AuthUseCases.kt
+++ b/budget-binder-multiplatform-app/src/commonMain/kotlin/de/hsfl/budgetBinder/domain/usecase/AuthUseCases.kt
@@ -6,5 +6,6 @@ data class AuthUseCases(
     val registerUseCase: RegisterUseCase,
     val isServerUrlStoredUseCase: IsServerUrlStoredUseCase,
     val getServerUrlUseCase: GetServerUrlUseCase,
-    val storeServerUrlUseCase: StoreServerUrlUseCase
+    val storeServerUrlUseCase: StoreServerUrlUseCase,
+    val toggleServerUrlDialogUseCase: ToggleServerUrlDialogUseCase
 )

--- a/budget-binder-multiplatform-app/src/commonMain/kotlin/de/hsfl/budgetBinder/domain/usecase/ToggleServerUrlDialogUseCase.kt
+++ b/budget-binder-multiplatform-app/src/commonMain/kotlin/de/hsfl/budgetBinder/domain/usecase/ToggleServerUrlDialogUseCase.kt
@@ -1,0 +1,15 @@
+package de.hsfl.budgetBinder.domain.usecase
+
+import kotlinx.coroutines.flow.*
+
+class ToggleServerUrlDialogUseCase {
+    private var dialog = false
+    private val _dialogState = MutableSharedFlow<Boolean>(replay = 0)
+    val dialogState: SharedFlow<Boolean> = _dialogState
+
+
+    suspend operator fun invoke() {
+        dialog = !dialog
+        _dialogState.emit(dialog)
+    }
+}

--- a/budget-binder-multiplatform-app/src/commonMain/kotlin/de/hsfl/budgetBinder/presentation/Screen.kt
+++ b/budget-binder-multiplatform-app/src/commonMain/kotlin/de/hsfl/budgetBinder/presentation/Screen.kt
@@ -1,28 +1,28 @@
 package de.hsfl.budgetBinder.presentation
-sealed class Screen {
-    sealed class Welcome: Screen() {
-        object Screen1: Welcome()
-        object Screen2: Welcome()
-        object GetStarted: Welcome()
+sealed class Screen(open val screenWeight: Int = 0) {
+    sealed class Welcome(override val screenWeight: Int = 0): Screen(screenWeight = screenWeight) {
+        object Screen1: Welcome(screenWeight = 0)
+        object Screen2: Welcome(screenWeight = 1)
+        object GetStarted: Welcome(screenWeight = 2)
     }
-    sealed class Settings: Screen() {
-        object Menu: Settings()
-        object User: Settings()
-        object Server: Settings()
+    sealed class Settings(override val screenWeight: Int = 0): Screen(screenWeight = screenWeight) {
+        object Menu: Settings(screenWeight = 0)
+        object User: Settings(screenWeight = 1)
+        object Server: Settings(screenWeight = 1)
     }
-    sealed class Category: Screen() {
-        data class Detail(val id: Int): Category()
-        object Summary: Category()
-        data class Edit(val id: Int): Category()
-        object Create: Category()
-        object CreateOnRegister: Category()
+    sealed class Category(override val screenWeight: Int = 0): Screen(screenWeight = screenWeight) {
+        data class Detail(val id: Int): Category(screenWeight = 1)
+        object Summary: Category(screenWeight = 0)
+        data class Edit(val id: Int): Category(screenWeight = 2)
+        object Create: Category(screenWeight = 2)
+        object CreateOnRegister: Category(screenWeight = 0)
     }
-    sealed class Entry: Screen() {
-        data class Overview(val id: Int): Entry()
-        data class Edit(val id: Int): Entry()
-        object Create: Entry()
+    sealed class Entry(override val screenWeight: Int = 0): Screen(screenWeight = screenWeight) {
+        data class Overview(val id: Int): Entry(screenWeight = 0)
+        data class Edit(val id: Int): Entry(screenWeight = 1)
+        object Create: Entry(screenWeight = 1)
     }
-    object Login : Screen()
-    object Register : Screen()
-    object Dashboard : Screen()
+    object Login : Screen(screenWeight = 0)
+    object Register : Screen(screenWeight = 0)
+    object Dashboard : Screen(screenWeight = 1)
 }

--- a/budget-binder-multiplatform-app/src/commonMain/kotlin/de/hsfl/budgetBinder/presentation/viewmodel/auth/AuthViewModel.kt
+++ b/budget-binder-multiplatform-app/src/commonMain/kotlin/de/hsfl/budgetBinder/presentation/viewmodel/auth/AuthViewModel.kt
@@ -9,6 +9,7 @@ import de.hsfl.budgetBinder.presentation.flow.UiEventSharedFlow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 
 open class AuthViewModel(
@@ -22,7 +23,18 @@ open class AuthViewModel(
     private val dataFlow = _dataFlow
     private val authUseCases = _authUseCases
 
+    private val _dialogState = MutableStateFlow(false)
+    val dialogState: StateFlow<Boolean> = _dialogState
+
     val eventFlow = UiEventSharedFlow.eventFlow
+
+    init {
+        scope.launch {
+            authUseCases.toggleServerUrlDialogUseCase.dialogState.collect {
+                _dialogState.value = it
+            }
+        }
+    }
 
     protected fun register(user: User.In, serverUrl: String) = scope.launch {
         authUseCases.registerUseCase(user)
@@ -52,5 +64,9 @@ open class AuthViewModel(
                 routerFlow.navigateTo(Screen.Dashboard)
             })
         }
+    }
+
+    fun toggleDialog() = scope.launch {
+        authUseCases.toggleServerUrlDialogUseCase()
     }
 }

--- a/budget-binder-multiplatform-app/src/commonMain/kotlin/de/hsfl/budgetBinder/presentation/viewmodel/auth/login/LoginViewModel.kt
+++ b/budget-binder-multiplatform-app/src/commonMain/kotlin/de/hsfl/budgetBinder/presentation/viewmodel/auth/login/LoginViewModel.kt
@@ -36,9 +36,6 @@ class LoginViewModel(
     private val _serverUrlText = MutableStateFlow(LoginTextFieldState())
     val serverUrlText: StateFlow<LoginTextFieldState> = _serverUrlText
 
-    private val _dialogState = MutableStateFlow(false)
-    val dialogState: StateFlow<Boolean> = _dialogState
-
     fun onEvent(event: LoginEvent) {
         when (event) {
             is LoginEvent.EnteredEmail -> _emailText.value =
@@ -61,6 +58,7 @@ class LoginViewModel(
             is LoginEvent.OnServerUrlDialogConfirm -> validateInput { onServerUrlDialogConfirm() }
             is LoginEvent.OnServerUrlDialogDismiss -> toggleDialog()
             is LoginEvent.LifeCycle -> event.value.handleLifeCycle(onLaunch = {
+                _serverUrlText.value = serverUrlText.value.copy(serverAddress = authUseCases.getServerUrlUseCase())
                 if (authUseCases.isServerUrlStoredUseCase()) {
                     tryToLoginUserOnStart()
                 }
@@ -97,10 +95,6 @@ class LoginViewModel(
 
     private fun storeUser(user: User) {
         dataFlow.storeUserState(user)
-    }
-
-    private fun toggleDialog() {
-        _dialogState.value = !dialogState.value
     }
 
     private fun clearStateFlows() {

--- a/budget-binder-multiplatform-app/src/commonMain/kotlin/de/hsfl/budgetBinder/presentation/viewmodel/auth/register/RegisterViewModel.kt
+++ b/budget-binder-multiplatform-app/src/commonMain/kotlin/de/hsfl/budgetBinder/presentation/viewmodel/auth/register/RegisterViewModel.kt
@@ -42,9 +42,6 @@ class RegisterViewModel(
     private val _serverUrlText = MutableStateFlow(RegisterTextFieldState())
     val serverUrlText: StateFlow<RegisterTextFieldState> = _serverUrlText
 
-    private val _dialogState = MutableStateFlow(false)
-    val dialogState: StateFlow<Boolean> = _dialogState
-
     fun onEvent(event: RegisterEvent) {
         when (event) {
             is RegisterEvent.EnteredFirstname -> _firstNameText.value =
@@ -127,9 +124,7 @@ class RegisterViewModel(
         _confirmedPasswordText.value = _confirmedPasswordText.value.copy(confirmedPassword = "")
     }
 
-    private fun toggleDialog() {
-        _dialogState.value = !dialogState.value
-    }
+
 
     // OLD!!!
     private val _state = MutableStateFlow<UiState>(UiState.Empty)

--- a/budget-binder-multiplatform-app/src/commonMain/kotlin/de/hsfl/budgetBinder/presentation/viewmodel/category/CategoryViewModel.kt
+++ b/budget-binder-multiplatform-app/src/commonMain/kotlin/de/hsfl/budgetBinder/presentation/viewmodel/category/CategoryViewModel.kt
@@ -8,6 +8,8 @@ import de.hsfl.budgetBinder.presentation.flow.UiEventSharedFlow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
 open class CategoryViewModel(
@@ -18,6 +20,14 @@ open class CategoryViewModel(
     private val scope: CoroutineScope = _scope
     private val categoriesUseCases: CategoriesUseCases = _categoriesUseCases
     private val routerFlow: RouterFlow = _routerFlow
+
+    /**
+     * Screen ID to Animate Content
+     * 0 means base layer (Category Summary)
+     * 1 means the next Layer (Category Deatil)
+     */
+    protected val _screenId = MutableStateFlow(0)
+    val screenId: StateFlow<Int> = _screenId
 
     val eventFlow = UiEventSharedFlow.mutableEventFlow
 

--- a/budget-binder-multiplatform-app/src/commonMain/kotlin/de/hsfl/budgetBinder/presentation/viewmodel/navdrawer/NavDrawerEvent.kt
+++ b/budget-binder-multiplatform-app/src/commonMain/kotlin/de/hsfl/budgetBinder/presentation/viewmodel/navdrawer/NavDrawerEvent.kt
@@ -1,6 +1,7 @@
 package de.hsfl.budgetBinder.presentation.viewmodel.navdrawer
 
 sealed class NavDrawerEvent {
+    object OnChangeServerUrl: NavDrawerEvent()
     object OnDashboard: NavDrawerEvent()
     object OnCreateEntry: NavDrawerEvent()
     object OnCategory: NavDrawerEvent()

--- a/budget-binder-multiplatform-app/src/commonMain/kotlin/de/hsfl/budgetBinder/presentation/viewmodel/navdrawer/NavDrawerViewModel.kt
+++ b/budget-binder-multiplatform-app/src/commonMain/kotlin/de/hsfl/budgetBinder/presentation/viewmodel/navdrawer/NavDrawerViewModel.kt
@@ -2,26 +2,26 @@ package de.hsfl.budgetBinder.presentation.viewmodel.navdrawer
 
 import de.hsfl.budgetBinder.common.DataResponse
 import de.hsfl.budgetBinder.domain.usecase.LogoutUseCase
+import de.hsfl.budgetBinder.domain.usecase.ToggleServerUrlDialogUseCase
 import de.hsfl.budgetBinder.presentation.Screen
 import de.hsfl.budgetBinder.presentation.UiState
 import de.hsfl.budgetBinder.presentation.flow.RouterFlow
 import de.hsfl.budgetBinder.presentation.flow.UiEventSharedFlow
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 
 class NavDrawerViewModel(
     private val logoutUseCase: LogoutUseCase,
+    private val toggleServerUrlDialogUseCase: ToggleServerUrlDialogUseCase,
     private val routerFlow: RouterFlow,
-    private val scope: CoroutineScope = CoroutineScope(Dispatchers.Unconfined + SupervisorJob()),
+    private val scope: CoroutineScope,
 ) {
-
     val eventFlow = UiEventSharedFlow.eventFlow
 
     fun onEvent(event: NavDrawerEvent) {
         when (event) {
+            is NavDrawerEvent.OnChangeServerUrl -> scope.launch { toggleServerUrlDialogUseCase() }
             is NavDrawerEvent.OnDashboard -> routerFlow.navigateTo(Screen.Dashboard)
             is NavDrawerEvent.OnCreateEntry -> routerFlow.navigateTo(Screen.Entry.Create)
             is NavDrawerEvent.OnCategory -> routerFlow.navigateTo(Screen.Category.Summary)
@@ -32,9 +32,8 @@ class NavDrawerViewModel(
 
     private fun logout() = scope.launch {
         logoutUseCase(onAllDevices = false).collect {
-                it.handleDataResponse<Nothing>(routerFlow = routerFlow,
-                    onSuccess = { routerFlow.navigateTo(Screen.Login) })
-            }
+            it.handleDataResponse<Nothing>(routerFlow = routerFlow, onSuccess = { routerFlow.navigateTo(Screen.Login) })
+        }
     }
 
     // Old

--- a/budget-binder-multiplatform-app/src/commonMain/kotlin/de/hsfl/budgetBinder/presentation/viewmodel/settings/SettingsEditUserViewModel.kt
+++ b/budget-binder-multiplatform-app/src/commonMain/kotlin/de/hsfl/budgetBinder/presentation/viewmodel/settings/SettingsEditUserViewModel.kt
@@ -19,13 +19,9 @@ class SettingsEditUserViewModel(
     private val routerFlow: RouterFlow,
     private val scope: CoroutineScope
 ) : SettingsViewModel(
-    _settingsUseCases = settingsUseCases,
-    _dataFlow = dataFlow,
-    _routerFlow = routerFlow,
-    _scope = scope
+    _settingsUseCases = settingsUseCases, _dataFlow = dataFlow, _routerFlow = routerFlow, _scope = scope
 ) {
-    private val _firstNameText =
-        MutableStateFlow(EditUserState())
+    private val _firstNameText = MutableStateFlow(EditUserState())
     val firstNameText: StateFlow<EditUserState> = _firstNameText
 
     private val _lastNameText = MutableStateFlow(EditUserState())
@@ -68,8 +64,7 @@ class SettingsEditUserViewModel(
                     if (passwordText.value.password == passwordPlaceholder) {
                         updateUser(
                             User.Patch(
-                                firstName = firstNameText.value.firstName,
-                                name = lastNameText.value.lastName
+                                firstName = firstNameText.value.firstName, name = lastNameText.value.lastName
                             )
                         )
                     } else {
@@ -91,65 +86,59 @@ class SettingsEditUserViewModel(
     }
 
     private fun checkValidInput(): Boolean {
-        val checkFirstName =
-            if (firstNameText.value.firstName.isBlank()) {
-                _firstNameText.value = firstNameText.value.copy(firstNameIsValid = false)
-                false
-            } else {
-                true
-            }
+        val checkFirstName = if (firstNameText.value.firstName.isBlank()) {
+            _firstNameText.value = firstNameText.value.copy(firstNameIsValid = false)
+            false
+        } else {
+            true
+        }
 
-        val checkLastName =
-            if (lastNameText.value.lastName.isBlank()) {
-                _lastNameText.value = lastNameText.value.copy(lastNameIsValid = false)
-                false
-            } else {
-                true
-            }
+        val checkLastName = if (lastNameText.value.lastName.isBlank()) {
+            _lastNameText.value = lastNameText.value.copy(lastNameIsValid = false)
+            false
+        } else {
+            true
+        }
 
-        val checkPassword =
-            if (passwordText.value.password.isBlank()) {
-                _passwordText.value = passwordText.value.copy(passwordIsValid = false)
-                false
-            } else {
-                true
-            }
+        val checkPassword = if (passwordText.value.password.isBlank()) {
+            _passwordText.value = passwordText.value.copy(passwordIsValid = false)
+            false
+        } else {
+            true
+        }
 
-        val checkConfirmedPassword =
-            if (passwordText.value.password == confirmedPassword.value.confirmedPassword) {
-                true
-            } else {
-                _confirmedPasswordText.value = confirmedPassword.value.copy(confirmedPasswordIsValid = false)
-                false
-            }
-
-
+        val checkConfirmedPassword = if (passwordText.value.password == confirmedPassword.value.confirmedPassword) {
+            true
+        } else {
+            _confirmedPasswordText.value = confirmedPassword.value.copy(confirmedPasswordIsValid = false)
+            false
+        }
         return checkFirstName && checkLastName && checkPassword && checkConfirmedPassword
     }
 
-    private fun updateUser(user: User.Patch) {
-        scope.launch {
-            settingsUseCases.changeMyUserUseCase(user).collect { response ->
-                when (response) {
-                    is DataResponse.Loading -> _eventFlow.emit(UiEvent.ShowLoading)
-                    is DataResponse.Error -> _eventFlow.emit(UiEvent.ShowError(response.error!!.message))
-                    is DataResponse.Success -> {
-                        // If user has changed his password, he needs to sign in again
-                        if (user.password != null) {
-                            logOutOnAllDevices("Your password was updated. Please sign in again")
-                        } else {
-                            _eventFlow.emit(UiEvent.ShowSuccess("User update successfully"))
-                            dataFlow.storeUserState(response.data!!)
-                            routerFlow.navigateTo(Screen.Settings.Menu)
-
-                        }
-                    }
-                    is DataResponse.Unauthorized -> {
-                        _eventFlow.emit(UiEvent.ShowError(response.error!!.message))
-                        routerFlow.navigateTo(Screen.Login)
-                    }
+    private fun updateUser(user: User.Patch) = scope.launch {
+        settingsUseCases.changeMyUserUseCase(user).collect { response ->
+            response.handleDataResponse<User>(routerFlow = routerFlow, onSuccess = {
+                if (user.password != null) {
+                    logOutOnAllDevices("Your password was updated. Please sign in again")
+                } else {
+                    _eventFlow.emit(UiEvent.ShowSuccess("User update successfully"))
+                    dataFlow.storeUserState(it)
+                    routerFlow.navigateTo(Screen.Settings.Menu)
                 }
-            }
+            })
+            /* when (response) {
+                 is DataResponse.Loading -> _eventFlow.emit(UiEvent.ShowLoading)
+                 is DataResponse.Error -> _eventFlow.emit(UiEvent.ShowError(response.error!!.message))
+                 is DataResponse.Success -> {
+                     // If user has changed his password, he needs to sign in again
+
+                 }
+                 is DataResponse.Unauthorized -> {
+                     _eventFlow.emit(UiEvent.ShowError(response.error!!.message))
+                     routerFlow.navigateTo(Screen.Login)
+                 }
+             }*/
         }
     }
 

--- a/budget-binder-multiplatform-app/src/desktopMain/kotlin/de/hsfl/budgetBinder/compose/dialog/ServerUrlDialog.kt
+++ b/budget-binder-multiplatform-app/src/desktopMain/kotlin/de/hsfl/budgetBinder/compose/dialog/ServerUrlDialog.kt
@@ -7,6 +7,7 @@ import androidx.compose.material.icons.filled.Dns
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 
 @OptIn(ExperimentalMaterialApi::class)
@@ -20,7 +21,7 @@ actual fun ServerUrlDialog(
 ) {
     if (openDialog) {
         AlertDialog(
-            title = { Text(text = "Please Enter Server URL", style = MaterialTheme.typography.body2) },
+            title = { Text(text = "Please enter server url", style = MaterialTheme.typography.body2, fontWeight = FontWeight.Bold) },
             onDismissRequest = onDismiss,
             buttons = {
                 Box(modifier = Modifier.fillMaxWidth()) {
@@ -33,13 +34,7 @@ actual fun ServerUrlDialog(
                 }
             },
             text = {
-                TextField(
-                    value = value,
-                    onValueChange = onValueChange,
-                    label = { Text("Server URL") },
-                    leadingIcon = { Icon(Icons.Filled.Dns, contentDescription = null) },
-                    singleLine = true
-                )
+
             }
         )
     }

--- a/budget-binder-multiplatform-app/src/jvmMain/kotlin/de/hsfl/budgetBinder/NavDrawer.kt
+++ b/budget-binder-multiplatform-app/src/jvmMain/kotlin/de/hsfl/budgetBinder/NavDrawer.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -12,7 +11,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import de.hsfl.budgetBinder.compose.icon.*
 import de.hsfl.budgetBinder.presentation.flow.DataFlow
-import de.hsfl.budgetBinder.presentation.viewmodel.auth.AuthViewModel
 import de.hsfl.budgetBinder.presentation.viewmodel.navdrawer.NavDrawerEvent
 import de.hsfl.budgetBinder.presentation.viewmodel.navdrawer.NavDrawerViewModel
 import kotlinx.coroutines.launch
@@ -24,7 +22,7 @@ fun BudgetBinderTopBar(
     navigationIcon: @Composable () -> Unit = {},
     actions: @Composable RowScope.() -> Unit = {}
 ) {
-    TopAppBar(title = { Text("Budget Binder") }, navigationIcon = navigationIcon, actions = actions)
+    TopAppBar(title = { Text(text) }, navigationIcon = navigationIcon, actions = actions)
 }
 
 @Composable

--- a/budget-binder-multiplatform-app/src/jvmMain/kotlin/de/hsfl/budgetBinder/NavDrawer.kt
+++ b/budget-binder-multiplatform-app/src/jvmMain/kotlin/de/hsfl/budgetBinder/NavDrawer.kt
@@ -42,6 +42,7 @@ fun TopBarMenuIcon(drawerState: DrawerState) {
 @Composable
 fun BudgetBinderAuthNavDrawer(drawerState: DrawerState, content: @Composable () -> Unit) {
     val scope = rememberCoroutineScope()
+    val viewModel: NavDrawerViewModel by di.instance()
     ModalDrawer(drawerState = drawerState, gesturesEnabled = true, content = content, drawerContent = {
         ListItem(icon = { AppIcon(modifier = Modifier.size(64.dp)) }, text = { Text("Budget Binder") })
         Divider()
@@ -49,6 +50,7 @@ fun BudgetBinderAuthNavDrawer(drawerState: DrawerState, content: @Composable () 
             scope.launch {
                 drawerState.close()
             }
+            viewModel.onEvent(NavDrawerEvent.OnChangeServerUrl)
         })
     })
 }

--- a/budget-binder-multiplatform-app/src/jvmMain/kotlin/de/hsfl/budgetBinder/NavDrawer.kt
+++ b/budget-binder-multiplatform-app/src/jvmMain/kotlin/de/hsfl/budgetBinder/NavDrawer.kt
@@ -3,6 +3,9 @@ package de.hsfl.budgetBinder
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Menu
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -14,63 +17,73 @@ import de.hsfl.budgetBinder.presentation.viewmodel.navdrawer.NavDrawerViewModel
 import kotlinx.coroutines.launch
 import org.kodein.di.instance
 
+@Composable
+fun BudgetBinderTopBar(
+    text: String = "Budget Binder",
+    navigationIcon: @Composable () -> Unit = {},
+    actions: @Composable RowScope.() -> Unit = {}
+) {
+    TopAppBar(title = { Text("Budget Binder") }, navigationIcon = navigationIcon, actions = actions)
+}
+
+@Composable
+fun TopBarMenuIcon(drawerState: DrawerState) {
+    val scope = rememberCoroutineScope()
+    IconButton(onClick = {
+        scope.launch {
+            if (drawerState.isOpen) drawerState.close()
+            else drawerState.open()
+        }
+    }) {
+        Icon(Icons.Default.Menu, contentDescription = null)
+    }
+}
+
+@Composable
+fun RowScope.TopBarDeleteIcon(onDelete: () -> Unit) {
+    IconButton(onClick = onDelete) {
+        Icon(Icons.Default.Delete, contentDescription = null)
+    }
+}
+
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
-fun NavDrawer(
-    drawerState: DrawerState,
-    gesturesEnabled: Boolean = true,
-    content: @Composable () -> Unit
+fun BudgetBinderNavDrawer(
+    drawerState: DrawerState, gesturesEnabled: Boolean = true, content: @Composable () -> Unit
 ) {
     val scope = rememberCoroutineScope()
     val viewModel: NavDrawerViewModel by di.instance()
-    ModalDrawer(
-        drawerState = drawerState,
-        gesturesEnabled = gesturesEnabled,
-        content = content,
-        drawerContent = {
-            UserData()
-            ListItem(
-                icon = { DashboardIcon() },
-                text = { Text("Dashboard") },
-                modifier = Modifier.clickable(onClick = {
-                    scope.launch {
-                        drawerState.close()
-                        viewModel.onEvent(NavDrawerEvent.OnDashboard)
-                    }
-                })
-            )
-            ListItem(
-                icon = { CategoryIcon() },
-                text = { Text("Categories") },
-                modifier = Modifier.clickable(onClick = {
-                    scope.launch {
-                        drawerState.close()
-                        viewModel.onEvent(NavDrawerEvent.OnCategory)
-                    }
-                })
-            )
-            ListItem(
-                icon = { SettingsIcon() },
-                text = { Text("Settings") },
-                modifier = Modifier.clickable(onClick = {
-                    scope.launch {
-                        drawerState.close()
-                        viewModel.onEvent(NavDrawerEvent.OnSettings)
-                    }
-                })
-            )
-            ListItem(
-                icon = { LogoutIcon() },
-                text = { Text("Logout") },
-                modifier = Modifier.clickable(onClick = {
-                    scope.launch {
-                        drawerState.close()
-                        viewModel.onEvent(NavDrawerEvent.OnLogout)
-                    }
-                })
-            )
-        }
-    )
+    ModalDrawer(drawerState = drawerState, gesturesEnabled = gesturesEnabled, content = content, drawerContent = {
+        UserData()
+        ListItem(icon = { DashboardIcon() }, text = { Text("Dashboard") }, modifier = Modifier.clickable(onClick = {
+            scope.launch {
+                drawerState.close()
+                viewModel.onEvent(NavDrawerEvent.OnDashboard)
+            }
+        })
+        )
+        ListItem(icon = { CategoryIcon() }, text = { Text("Categories") }, modifier = Modifier.clickable(onClick = {
+            scope.launch {
+                drawerState.close()
+                viewModel.onEvent(NavDrawerEvent.OnCategory)
+            }
+        })
+        )
+        ListItem(icon = { SettingsIcon() }, text = { Text("Settings") }, modifier = Modifier.clickable(onClick = {
+            scope.launch {
+                drawerState.close()
+                viewModel.onEvent(NavDrawerEvent.OnSettings)
+            }
+        })
+        )
+        ListItem(icon = { LogoutIcon() }, text = { Text("Logout") }, modifier = Modifier.clickable(onClick = {
+            scope.launch {
+                drawerState.close()
+                viewModel.onEvent(NavDrawerEvent.OnLogout)
+            }
+        })
+        )
+    })
 }
 
 @Composable
@@ -79,7 +92,7 @@ fun UserData() {
     val userData = dataFlow.userState.collectAsState()
 
     Column {
-        Row(modifier = Modifier.padding(8.dp),verticalAlignment = Alignment.CenterVertically) {
+        Row(modifier = Modifier.padding(8.dp), verticalAlignment = Alignment.CenterVertically) {
             AvatarImage(modifier = Modifier.size(64.dp))
             Spacer(modifier = Modifier.width(16.dp))
             Column(verticalArrangement = Arrangement.Center) {

--- a/budget-binder-multiplatform-app/src/jvmMain/kotlin/de/hsfl/budgetBinder/NavDrawer.kt
+++ b/budget-binder-multiplatform-app/src/jvmMain/kotlin/de/hsfl/budgetBinder/NavDrawer.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import de.hsfl.budgetBinder.compose.icon.*
 import de.hsfl.budgetBinder.presentation.flow.DataFlow
+import de.hsfl.budgetBinder.presentation.viewmodel.auth.AuthViewModel
 import de.hsfl.budgetBinder.presentation.viewmodel.navdrawer.NavDrawerEvent
 import de.hsfl.budgetBinder.presentation.viewmodel.navdrawer.NavDrawerViewModel
 import kotlinx.coroutines.launch
@@ -39,21 +40,29 @@ fun TopBarMenuIcon(drawerState: DrawerState) {
     }
 }
 
+@OptIn(ExperimentalMaterialApi::class)
 @Composable
-fun RowScope.TopBarDeleteIcon(onDelete: () -> Unit) {
-    IconButton(onClick = onDelete) {
-        Icon(Icons.Default.Delete, contentDescription = null)
-    }
+fun BudgetBinderAuthNavDrawer(drawerState: DrawerState, content: @Composable () -> Unit) {
+    val scope = rememberCoroutineScope()
+    ModalDrawer(drawerState = drawerState, gesturesEnabled = true, content = content, drawerContent = {
+        ListItem(icon = { AppIcon(modifier = Modifier.size(64.dp)) }, text = { Text("Budget Binder") })
+        Divider()
+        ListItem(icon = { ServerIcon() }, text = { Text("Change Server URL") }, modifier = Modifier.clickable {
+            scope.launch {
+                drawerState.close()
+            }
+        })
+    })
 }
 
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun BudgetBinderNavDrawer(
-    drawerState: DrawerState, gesturesEnabled: Boolean = true, content: @Composable () -> Unit
+    drawerState: DrawerState, content: @Composable () -> Unit
 ) {
     val scope = rememberCoroutineScope()
     val viewModel: NavDrawerViewModel by di.instance()
-    ModalDrawer(drawerState = drawerState, gesturesEnabled = gesturesEnabled, content = content, drawerContent = {
+    ModalDrawer(drawerState = drawerState, gesturesEnabled = true, content = content, drawerContent = {
         UserData()
         ListItem(icon = { DashboardIcon() }, text = { Text("Dashboard") }, modifier = Modifier.clickable(onClick = {
             scope.launch {

--- a/budget-binder-multiplatform-app/src/jvmMain/kotlin/de/hsfl/budgetBinder/Root.kt
+++ b/budget-binder-multiplatform-app/src/jvmMain/kotlin/de/hsfl/budgetBinder/Root.kt
@@ -8,8 +8,10 @@ import androidx.compose.material.icons.filled.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import de.hsfl.budgetBinder.di.kodein
+import de.hsfl.budgetBinder.presentation.Screen
 import de.hsfl.budgetBinder.presentation.event.UiEvent
 import de.hsfl.budgetBinder.presentation.flow.DataFlow
+import de.hsfl.budgetBinder.presentation.flow.RouterFlow
 import de.hsfl.budgetBinder.presentation.flow.UiEventSharedFlow
 import io.ktor.client.engine.cio.*
 import kotlinx.coroutines.flow.collectLatest
@@ -24,10 +26,11 @@ fun App() = withDI(di) {
     val scope = rememberCoroutineScope()
     val dataFlow: DataFlow by di.instance()
     val uiEventFlow: UiEventSharedFlow by di.instance()
+    val routerFlow: RouterFlow by di.instance()
+    val screenState = routerFlow.state.collectAsState()
     val darkTheme = dataFlow.darkModeState.collectAsState(scope.coroutineContext)
     val scaffoldState = rememberScaffoldState()
     val loadingState = remember { mutableStateOf(false) }
-    val drawerState = rememberDrawerState(DrawerValue.Closed)
 
     LaunchedEffect(key1 = true) {
         uiEventFlow.eventFlow.collectLatest { event ->
@@ -58,8 +61,20 @@ fun App() = withDI(di) {
         if (loadingState.value) {
             LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
         }
-        Scaffold(scaffoldState = scaffoldState,) {
-            Router()
+        Scaffold(scaffoldState = scaffoldState,
+        topBar = { BudgetBinderTopBar(navigationIcon = { TopBarMenuIcon(drawerState = scaffoldState.drawerState) }) }) {
+            when (screenState.value) {
+                is Screen.Login, is Screen.Register -> {
+                    BudgetBinderAuthNavDrawer(scaffoldState.drawerState) {
+                        Router()
+                    }
+                }
+                else -> {
+                    BudgetBinderNavDrawer(scaffoldState.drawerState) {
+                        Router()
+                    }
+                }
+            }
         }
     }
 }

--- a/budget-binder-multiplatform-app/src/jvmMain/kotlin/de/hsfl/budgetBinder/Root.kt
+++ b/budget-binder-multiplatform-app/src/jvmMain/kotlin/de/hsfl/budgetBinder/Root.kt
@@ -58,25 +58,8 @@ fun App() = withDI(di) {
         if (loadingState.value) {
             LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
         }
-        Scaffold(
-            scaffoldState = scaffoldState,
-            topBar = {
-                // TODO: Show NavDrawer not on Login und Register
-                TopAppBar(title = { Text("Budget Binder") }, navigationIcon = {
-                    IconButton(onClick = {
-                        scope.launch {
-                            if (drawerState.isOpen) drawerState.close()
-                            else drawerState.open()
-                        }
-                    }) {
-                        Icon(Icons.Filled.Menu, contentDescription = null)
-                    }
-                })
-            }
-        ) {
-            NavDrawer(drawerState = drawerState) {
-                Router()
-            }
+        Scaffold(scaffoldState = scaffoldState,) {
+            Router()
         }
     }
 }

--- a/budget-binder-multiplatform-app/src/jvmMain/kotlin/de/hsfl/budgetBinder/Router.kt
+++ b/budget-binder-multiplatform-app/src/jvmMain/kotlin/de/hsfl/budgetBinder/Router.kt
@@ -27,10 +27,7 @@ fun Router() {
         is Screen.Settings.Menu, Screen.Settings.User, Screen.Settings.Server -> SettingsView()
         is Screen.Entry.Overview -> Text(text = "Entry Click with id: ${(screenState.value as Screen.Entry.Overview).id}")
         is Screen.Entry.Create -> Text(text = "Entry Create")
-        is Screen.Category.Summary -> CategoryComponent()
-        is Screen.Category.Detail -> CategoryComponent()
-        is Screen.Category.Edit -> CategoryComponent()
-        is Screen.Category.Create -> CategoryComponent()
+        is Screen.Category.Summary, is Screen.Category.Detail, is Screen.Category.Edit, is Screen.Category.Create  -> CategoryComponent()
         else -> {}
     }
 }

--- a/budget-binder-multiplatform-app/src/jvmMain/kotlin/de/hsfl/budgetBinder/Router.kt
+++ b/budget-binder-multiplatform-app/src/jvmMain/kotlin/de/hsfl/budgetBinder/Router.kt
@@ -1,5 +1,6 @@
 package de.hsfl.budgetBinder
 
+import androidx.compose.animation.*
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState

--- a/budget-binder-multiplatform-app/src/jvmMain/kotlin/de/hsfl/budgetBinder/screens/category/CategoryComponent.kt
+++ b/budget-binder-multiplatform-app/src/jvmMain/kotlin/de/hsfl/budgetBinder/screens/category/CategoryComponent.kt
@@ -1,18 +1,30 @@
 package de.hsfl.budgetBinder.screens.category
 
+import androidx.compose.animation.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import de.hsfl.budgetBinder.di
 import de.hsfl.budgetBinder.presentation.Screen
 import de.hsfl.budgetBinder.presentation.flow.RouterFlow
 import org.kodein.di.instance
 
+@OptIn(ExperimentalAnimationApi::class)
 @Composable
 fun CategoryComponent() {
     val routerFlow: RouterFlow by di.instance()
-    when (routerFlow.state.value) {
-        is Screen.Category.Summary -> CategorySummary()
-        is Screen.Category.Detail -> CategoryDetailView()
-        is Screen.Category.Edit -> CategoryEditView()
-        is Screen.Category.Create -> CategoryCreateView()
+    val screenState = routerFlow.state.collectAsState()
+    AnimatedContent(targetState = screenState.value, transitionSpec = {
+        if (targetState.screenWeight > initialState.screenWeight) {
+            slideInHorizontally { fullWidth -> fullWidth } + fadeIn() with slideOutHorizontally { fullWidth -> -fullWidth }
+        } else {
+            slideInHorizontally { fullWidth -> -fullWidth } + fadeIn() with slideOutHorizontally { fullWidth -> fullWidth }
+        }.using(SizeTransform(clip = false))
+    }) { state ->
+        when (state) {
+            is Screen.Category.Summary -> CategorySummary()
+            is Screen.Category.Detail -> CategoryDetailView()
+            is Screen.Category.Edit -> CategoryEditView()
+            is Screen.Category.Create -> CategoryCreateView()
+        }
     }
 }

--- a/budget-binder-multiplatform-app/src/jvmMain/kotlin/de/hsfl/budgetBinder/screens/category/CategorySummary.kt
+++ b/budget-binder-multiplatform-app/src/jvmMain/kotlin/de/hsfl/budgetBinder/screens/category/CategorySummary.kt
@@ -46,37 +46,25 @@ fun CategorySummary() {
         }
     }
 
-    Scaffold(scaffoldState = scaffoldState,
-        floatingActionButtonPosition = FabPosition.End,
-        floatingActionButton = {
-            FloatingActionButton(onClick = { viewModel.onEvent(CategorySummaryEvent.OnCategoryCreate) }) {
-                Icon(Icons.Default.Add, contentDescription = null)
-            }
-        },
-        topBar = {
-            BudgetBinderTopBar(
-                navigationIcon = { TopBarMenuIcon(drawerState = scaffoldState.drawerState) }
-            )
+    Scaffold(scaffoldState = scaffoldState, floatingActionButtonPosition = FabPosition.End, floatingActionButton = {
+        FloatingActionButton(onClick = { viewModel.onEvent(CategorySummaryEvent.OnCategoryCreate) }) {
+            Icon(Icons.Default.Add, contentDescription = null)
         }
-    ) {
-        BudgetBinderNavDrawer(
-            drawerState = scaffoldState.drawerState,
-            gesturesEnabled = true
-        ) {
-            LazyColumn {
-                items(categoryList.value) { category ->
-                    CategoryListItem(
-                        modifier = Modifier.clickable { viewModel.onEvent(CategorySummaryEvent.OnCategory(category.id)) },
-                        name = category.name,
-                        budget = category.budget.toString(),
-                        icon = category.image,
-                        color = category.color.toColor("af")
-                    )
-                }
+    }) {
+        LazyColumn {
+            items(categoryList.value) { category ->
+                CategoryListItem(
+                    modifier = Modifier.clickable { viewModel.onEvent(CategorySummaryEvent.OnCategory(category.id)) },
+                    name = category.name,
+                    budget = category.budget.toString(),
+                    icon = category.image,
+                    color = category.color.toColor("af")
+                )
             }
         }
     }
 }
+
 
 fun String.toColor(alpha: String): Color {
     return Color("$alpha$this".toLong(16))
@@ -85,22 +73,13 @@ fun String.toColor(alpha: String): Color {
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun CategoryListItem(
-    modifier: Modifier = Modifier,
-    name: String,
-    budget: String,
-    icon: Category.Image,
-    color: Color
+    modifier: Modifier = Modifier, name: String, budget: String, icon: Category.Image, color: Color
 ) {
-    ListItem(
-        modifier = modifier,
-        text = { Text(name) },
-        secondaryText = { Text("Budget: $budget") },
-        icon = {
-            Box(modifier = Modifier.shadow(15.dp, CircleShape).clip(CircleShape).background(color)) {
-                Box(modifier = Modifier.align(Alignment.Center).padding(12.dp)) {
-                    CategoryImageToIcon(icon)
-                }
+    ListItem(modifier = modifier, text = { Text(name) }, secondaryText = { Text("Budget: $budget") }, icon = {
+        Box(modifier = Modifier.shadow(15.dp, CircleShape).clip(CircleShape).background(color)) {
+            Box(modifier = Modifier.align(Alignment.Center).padding(12.dp)) {
+                CategoryImageToIcon(icon)
             }
         }
-    )
+    })
 }

--- a/budget-binder-multiplatform-app/src/jvmMain/kotlin/de/hsfl/budgetBinder/screens/category/CategorySummary.kt
+++ b/budget-binder-multiplatform-app/src/jvmMain/kotlin/de/hsfl/budgetBinder/screens/category/CategorySummary.kt
@@ -16,6 +16,9 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import de.hsfl.budgetBinder.BudgetBinderNavDrawer
+import de.hsfl.budgetBinder.BudgetBinderTopBar
+import de.hsfl.budgetBinder.TopBarMenuIcon
 import de.hsfl.budgetBinder.common.Category
 import de.hsfl.budgetBinder.di
 import de.hsfl.budgetBinder.presentation.CategoryImageToIcon
@@ -49,18 +52,27 @@ fun CategorySummary() {
             FloatingActionButton(onClick = { viewModel.onEvent(CategorySummaryEvent.OnCategoryCreate) }) {
                 Icon(Icons.Default.Add, contentDescription = null)
             }
+        },
+        topBar = {
+            BudgetBinderTopBar(
+                navigationIcon = { TopBarMenuIcon(scaffoldState = scaffoldState) }
+            )
         }
     ) {
-        if (loadingState.value) LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
-        LazyColumn {
-            items(categoryList.value) { category ->
-                CategoryListItem(
-                    modifier = Modifier.clickable { viewModel.onEvent(CategorySummaryEvent.OnCategory(category.id)) },
-                    name = category.name,
-                    budget = category.budget.toString(),
-                    icon = category.image,
-                    color = category.color.toColor("af")
-                )
+        BudgetBinderNavDrawer(
+            drawerState = scaffoldState.drawerState,
+            gesturesEnabled = true
+        ) {
+            LazyColumn {
+                items(categoryList.value) { category ->
+                    CategoryListItem(
+                        modifier = Modifier.clickable { viewModel.onEvent(CategorySummaryEvent.OnCategory(category.id)) },
+                        name = category.name,
+                        budget = category.budget.toString(),
+                        icon = category.image,
+                        color = category.color.toColor("af")
+                    )
+                }
             }
         }
     }

--- a/budget-binder-multiplatform-app/src/jvmMain/kotlin/de/hsfl/budgetBinder/screens/category/CategorySummary.kt
+++ b/budget-binder-multiplatform-app/src/jvmMain/kotlin/de/hsfl/budgetBinder/screens/category/CategorySummary.kt
@@ -55,7 +55,7 @@ fun CategorySummary() {
         },
         topBar = {
             BudgetBinderTopBar(
-                navigationIcon = { TopBarMenuIcon(scaffoldState = scaffoldState) }
+                navigationIcon = { TopBarMenuIcon(drawerState = scaffoldState.drawerState) }
             )
         }
     ) {

--- a/budget-binder-multiplatform-app/src/jvmMain/kotlin/de/hsfl/budgetBinder/screens/dashboard/DashboardComponent.kt
+++ b/budget-binder-multiplatform-app/src/jvmMain/kotlin/de/hsfl/budgetBinder/screens/dashboard/DashboardComponent.kt
@@ -17,6 +17,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
+import de.hsfl.budgetBinder.BudgetBinderNavDrawer
+import de.hsfl.budgetBinder.BudgetBinderTopBar
+import de.hsfl.budgetBinder.TopBarMenuIcon
 import de.hsfl.budgetBinder.common.Category
 import de.hsfl.budgetBinder.compose.BudgetBar
 import de.hsfl.budgetBinder.di
@@ -63,25 +66,30 @@ fun DashboardComponent() {
         FloatingActionButton(onClick = { viewModel.onEvent(DashboardEvent.OnEntryCreate) }) {
             Icon(Icons.Default.Add, contentDescription = null)
         }
+    }, topBar = {
+        BudgetBinderTopBar(navigationIcon = { TopBarMenuIcon(scaffoldState = scaffoldState) })
     }) {
-        Column {
-            if (loadingState.value) {
-                LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
-            }
-            TopDashboardSection(focusedCategory = focusedCategory.value.category,
-                totalSpendBudget = totalSpendBudget.value.spendBudgetOnCurrentCategory,
-                totalBudget = focusedCategory.value.category.budget,
-                hasPrev = focusedCategory.value.hasPrev,
-                hasNext = focusedCategory.value.hasNext,
-                onPrevClicked = { viewModel.onEvent(DashboardEvent.OnPrevCategory) },
-                onNextClicked = { viewModel.onEvent(DashboardEvent.OnNextCategory) })
+        BudgetBinderNavDrawer(
+            scaffoldState.drawerState, gesturesEnabled = true
+        ) {
             Column {
-                EntryList(entryList = entryList.value.entryList,
-                    oldEntries = olderEntries.value,
-                    onItemClicked = { viewModel.onEvent(DashboardEvent.OnEntry(it)) },
-                    onLoadMore = { viewModel.onEvent(DashboardEvent.OnLoadMore) },
-                    onEntryDelete = { viewModel.onEvent(DashboardEvent.OnEntryDelete(it)) }
-                )
+                if (loadingState.value) {
+                    LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+                }
+                TopDashboardSection(focusedCategory = focusedCategory.value.category,
+                    totalSpendBudget = totalSpendBudget.value.spendBudgetOnCurrentCategory,
+                    totalBudget = focusedCategory.value.category.budget,
+                    hasPrev = focusedCategory.value.hasPrev,
+                    hasNext = focusedCategory.value.hasNext,
+                    onPrevClicked = { viewModel.onEvent(DashboardEvent.OnPrevCategory) },
+                    onNextClicked = { viewModel.onEvent(DashboardEvent.OnNextCategory) })
+                Column {
+                    EntryList(entryList = entryList.value.entryList,
+                        oldEntries = olderEntries.value,
+                        onItemClicked = { viewModel.onEvent(DashboardEvent.OnEntry(it)) },
+                        onLoadMore = { viewModel.onEvent(DashboardEvent.OnLoadMore) },
+                        onEntryDelete = { viewModel.onEvent(DashboardEvent.OnEntryDelete(it)) })
+                }
             }
         }
     }
@@ -214,11 +222,7 @@ fun SwipeToDelete(dismissState: DismissState, content: @Composable RowScope.() -
             }
             val scale by animateFloatAsState(targetValue = if (dismissState.targetValue == DismissValue.Default) 0.75f else 1f)
             Box(
-                Modifier
-                    .fillMaxSize()
-                    .background(color)
-                    .padding(horizontal = 20.dp),
-                contentAlignment = alignment
+                Modifier.fillMaxSize().background(color).padding(horizontal = 20.dp), contentAlignment = alignment
             ) {
                 if (direction == DismissDirection.EndToStart) {
                     Icon(Icons.Default.Delete, contentDescription = null, modifier = Modifier.scale(scale))

--- a/budget-binder-multiplatform-app/src/jvmMain/kotlin/de/hsfl/budgetBinder/screens/dashboard/DashboardComponent.kt
+++ b/budget-binder-multiplatform-app/src/jvmMain/kotlin/de/hsfl/budgetBinder/screens/dashboard/DashboardComponent.kt
@@ -65,30 +65,24 @@ fun DashboardComponent() {
         FloatingActionButton(onClick = { viewModel.onEvent(DashboardEvent.OnEntryCreate) }) {
             Icon(Icons.Default.Add, contentDescription = null)
         }
-    }, topBar = {
-        BudgetBinderTopBar(navigationIcon = { TopBarMenuIcon(drawerState = scaffoldState.drawerState) })
     }) {
-        BudgetBinderNavDrawer(
-            scaffoldState.drawerState, gesturesEnabled = true
-        ) {
+        Column {
+            if (loadingState.value) {
+                LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+            }
+            TopDashboardSection(focusedCategory = focusedCategory.value.category,
+                totalSpendBudget = focusedCategory.value.spendBudget,
+                totalBudget = focusedCategory.value.category.budget,
+                hasPrev = focusedCategory.value.hasPrev,
+                hasNext = focusedCategory.value.hasNext,
+                onPrevClicked = { viewModel.onEvent(DashboardEvent.OnPrevCategory) },
+                onNextClicked = { viewModel.onEvent(DashboardEvent.OnNextCategory) })
             Column {
-                if (loadingState.value) {
-                    LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
-                }
-                TopDashboardSection(focusedCategory = focusedCategory.value.category,
-                    totalSpendBudget = focusedCategory.value.spendBudget,
-                    totalBudget = focusedCategory.value.category.budget,
-                    hasPrev = focusedCategory.value.hasPrev,
-                    hasNext = focusedCategory.value.hasNext,
-                    onPrevClicked = { viewModel.onEvent(DashboardEvent.OnPrevCategory) },
-                    onNextClicked = { viewModel.onEvent(DashboardEvent.OnNextCategory) })
-                Column {
-                    EntryList(entryList = entryList.value,
-                        oldEntries = olderEntries.value,
-                        onItemClicked = { viewModel.onEvent(DashboardEvent.OnEntry(it)) },
-                        onLoadMore = { viewModel.onEvent(DashboardEvent.OnLoadMore) },
-                        onEntryDelete = { viewModel.onEvent(DashboardEvent.OnEntryDelete(it)) })
-                }
+                EntryList(entryList = entryList.value,
+                    oldEntries = olderEntries.value,
+                    onItemClicked = { viewModel.onEvent(DashboardEvent.OnEntry(it)) },
+                    onLoadMore = { viewModel.onEvent(DashboardEvent.OnLoadMore) },
+                    onEntryDelete = { viewModel.onEvent(DashboardEvent.OnEntryDelete(it)) })
             }
         }
     }

--- a/budget-binder-multiplatform-app/src/jvmMain/kotlin/de/hsfl/budgetBinder/screens/dashboard/DashboardComponent.kt
+++ b/budget-binder-multiplatform-app/src/jvmMain/kotlin/de/hsfl/budgetBinder/screens/dashboard/DashboardComponent.kt
@@ -39,7 +39,6 @@ fun DashboardComponent() {
     val viewModel: DashboardViewModel by di.instance()
     val entryList = viewModel.entryListState.collectAsState()
     val focusedCategory = viewModel.focusedCategoryState.collectAsState()
-    val totalSpendBudget = viewModel.spendBudgetOnCurrentCategory.collectAsState()
     val olderEntries = viewModel.oldEntriesMapState.collectAsState()
     val loadingState = remember { mutableStateOf(false) }
     val scaffoldState = rememberScaffoldState()
@@ -67,7 +66,7 @@ fun DashboardComponent() {
             Icon(Icons.Default.Add, contentDescription = null)
         }
     }, topBar = {
-        BudgetBinderTopBar(navigationIcon = { TopBarMenuIcon(scaffoldState = scaffoldState) })
+        BudgetBinderTopBar(navigationIcon = { TopBarMenuIcon(drawerState = scaffoldState.drawerState) })
     }) {
         BudgetBinderNavDrawer(
             scaffoldState.drawerState, gesturesEnabled = true
@@ -77,14 +76,14 @@ fun DashboardComponent() {
                     LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
                 }
                 TopDashboardSection(focusedCategory = focusedCategory.value.category,
-                    totalSpendBudget = totalSpendBudget.value.spendBudgetOnCurrentCategory,
+                    totalSpendBudget = focusedCategory.value.spendBudget,
                     totalBudget = focusedCategory.value.category.budget,
                     hasPrev = focusedCategory.value.hasPrev,
                     hasNext = focusedCategory.value.hasNext,
                     onPrevClicked = { viewModel.onEvent(DashboardEvent.OnPrevCategory) },
                     onNextClicked = { viewModel.onEvent(DashboardEvent.OnNextCategory) })
                 Column {
-                    EntryList(entryList = entryList.value.entryList,
+                    EntryList(entryList = entryList.value,
                         oldEntries = olderEntries.value,
                         onItemClicked = { viewModel.onEvent(DashboardEvent.OnEntry(it)) },
                         onLoadMore = { viewModel.onEvent(DashboardEvent.OnLoadMore) },

--- a/budget-binder-multiplatform-app/src/jvmMain/kotlin/de/hsfl/budgetBinder/screens/login/LoginComponent.kt
+++ b/budget-binder-multiplatform-app/src/jvmMain/kotlin/de/hsfl/budgetBinder/screens/login/LoginComponent.kt
@@ -10,6 +10,9 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
+import de.hsfl.budgetBinder.BudgetBinderNavDrawer
+import de.hsfl.budgetBinder.BudgetBinderTopBar
+import de.hsfl.budgetBinder.TopBarMenuIcon
 import de.hsfl.budgetBinder.di
 import de.hsfl.budgetBinder.compose.dialog.ServerUrlDialog
 import de.hsfl.budgetBinder.compose.icon.AppIcon
@@ -31,7 +34,7 @@ fun LoginComponent() {
     val openDialog = viewModel.dialogState.collectAsState(scope.coroutineContext)
     val localFocusManager = LocalFocusManager.current
     val loadingState = remember { mutableStateOf(false) }
-
+    val scaffoldState = rememberScaffoldState()
 
     LaunchedEffect(key1 = true) {
         viewModel.onEvent(LoginEvent.LifeCycle(LifecycleEvent.OnLaunch))
@@ -46,44 +49,47 @@ fun LoginComponent() {
     if (loadingState.value) {
         LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
     }
-    ServerUrlDialog(
-        value = serverUrlState.value.serverAddress,
+    ServerUrlDialog(value = serverUrlState.value.serverAddress,
         onValueChange = { viewModel.onEvent(LoginEvent.EnteredServerUrl(it)) },
         openDialog = openDialog.value,
         onConfirm = { viewModel.onEvent(LoginEvent.OnServerUrlDialogConfirm) },
-        onDismiss = { viewModel.onEvent(LoginEvent.OnServerUrlDialogDismiss) }
-    )
-    Column(modifier = Modifier.fillMaxSize(), horizontalAlignment = Alignment.CenterHorizontally) {
-        AppIcon(modifier = Modifier.size(128.dp).padding(8.dp))
-        Text(text = "Welcome back to Budget Binder 💸", style = MaterialTheme.typography.h5)
-        Spacer(modifier = Modifier.height(8.dp))
-        EmailTextField(
-            value = emailTextState.value.email,
-            onValueChange = { viewModel.onEvent(LoginEvent.EnteredEmail(it)) },
-            label = { Text("Email") },
-            isError = !emailTextState.value.emailValid,
-            enabled = !loadingState.value
-        )
-        OutlinedTextField(
-            value = passwordTextState.value.password,
-            onValueChange = { viewModel.onEvent(LoginEvent.EnteredPassword(it)) },
-            label = { Text("Password") },
-            visualTransformation = PasswordVisualTransformation(),
-            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
-            singleLine = true
-        )
-        Button(onClick = {
-            localFocusManager.clearFocus()
-            viewModel.onEvent(LoginEvent.OnLogin)
-        }) {
-            Text("Login")
-        }
-        Box(modifier = Modifier.fillMaxSize()) {
-            TextButton(modifier = Modifier.align(Alignment.BottomCenter), onClick = {
-                localFocusManager.clearFocus()
-                viewModel.onEvent(LoginEvent.OnRegisterScreen)
-            }) {
-                Text("Or Register your Account here")
+        onDismiss = { viewModel.onEvent(LoginEvent.OnServerUrlDialogDismiss) })
+    Scaffold(scaffoldState = scaffoldState,
+        topBar = { BudgetBinderTopBar() }) {
+        BudgetBinderNavDrawer(drawerState = scaffoldState.drawerState, gesturesEnabled = false) {
+            Column(modifier = Modifier.fillMaxSize(), horizontalAlignment = Alignment.CenterHorizontally) {
+                AppIcon(modifier = Modifier.size(128.dp).padding(8.dp))
+                Text(text = "Welcome back to Budget Binder 💸", style = MaterialTheme.typography.h5)
+                Spacer(modifier = Modifier.height(8.dp))
+                EmailTextField(
+                    value = emailTextState.value.email,
+                    onValueChange = { viewModel.onEvent(LoginEvent.EnteredEmail(it)) },
+                    label = { Text("Email") },
+                    isError = !emailTextState.value.emailValid,
+                    enabled = !loadingState.value
+                )
+                OutlinedTextField(
+                    value = passwordTextState.value.password,
+                    onValueChange = { viewModel.onEvent(LoginEvent.EnteredPassword(it)) },
+                    label = { Text("Password") },
+                    visualTransformation = PasswordVisualTransformation(),
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+                    singleLine = true
+                )
+                Button(onClick = {
+                    localFocusManager.clearFocus()
+                    viewModel.onEvent(LoginEvent.OnLogin)
+                }) {
+                    Text("Login")
+                }
+                Box(modifier = Modifier.fillMaxSize()) {
+                    TextButton(modifier = Modifier.align(Alignment.BottomCenter), onClick = {
+                        localFocusManager.clearFocus()
+                        viewModel.onEvent(LoginEvent.OnRegisterScreen)
+                    }) {
+                        Text("Or Register your Account here")
+                    }
+                }
             }
         }
     }

--- a/budget-binder-multiplatform-app/src/jvmMain/kotlin/de/hsfl/budgetBinder/screens/login/LoginComponent.kt
+++ b/budget-binder-multiplatform-app/src/jvmMain/kotlin/de/hsfl/budgetBinder/screens/login/LoginComponent.kt
@@ -54,43 +54,41 @@ fun LoginComponent() {
         openDialog = openDialog.value,
         onConfirm = { viewModel.onEvent(LoginEvent.OnServerUrlDialogConfirm) },
         onDismiss = { viewModel.onEvent(LoginEvent.OnServerUrlDialogDismiss) })
-    Scaffold(scaffoldState = scaffoldState,
-        topBar = { BudgetBinderTopBar() }) {
-        BudgetBinderNavDrawer(drawerState = scaffoldState.drawerState, gesturesEnabled = false) {
-            Column(modifier = Modifier.fillMaxSize(), horizontalAlignment = Alignment.CenterHorizontally) {
-                AppIcon(modifier = Modifier.size(128.dp).padding(8.dp))
-                Text(text = "Welcome back to Budget Binder 💸", style = MaterialTheme.typography.h5)
-                Spacer(modifier = Modifier.height(8.dp))
-                EmailTextField(
-                    value = emailTextState.value.email,
-                    onValueChange = { viewModel.onEvent(LoginEvent.EnteredEmail(it)) },
-                    label = { Text("Email") },
-                    isError = !emailTextState.value.emailValid,
-                    enabled = !loadingState.value
-                )
-                OutlinedTextField(
-                    value = passwordTextState.value.password,
-                    onValueChange = { viewModel.onEvent(LoginEvent.EnteredPassword(it)) },
-                    label = { Text("Password") },
-                    visualTransformation = PasswordVisualTransformation(),
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
-                    singleLine = true
-                )
-                Button(onClick = {
+    Scaffold(scaffoldState = scaffoldState) {
+        Column(modifier = Modifier.fillMaxSize(), horizontalAlignment = Alignment.CenterHorizontally) {
+            AppIcon(modifier = Modifier.size(128.dp).padding(8.dp))
+            Text(text = "Welcome back to Budget Binder 💸", style = MaterialTheme.typography.h5)
+            Spacer(modifier = Modifier.height(8.dp))
+            EmailTextField(
+                value = emailTextState.value.email,
+                onValueChange = { viewModel.onEvent(LoginEvent.EnteredEmail(it)) },
+                label = { Text("Email") },
+                isError = !emailTextState.value.emailValid,
+                enabled = !loadingState.value
+            )
+            OutlinedTextField(
+                value = passwordTextState.value.password,
+                onValueChange = { viewModel.onEvent(LoginEvent.EnteredPassword(it)) },
+                label = { Text("Password") },
+                visualTransformation = PasswordVisualTransformation(),
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+                singleLine = true
+            )
+            Button(onClick = {
+                localFocusManager.clearFocus()
+                viewModel.onEvent(LoginEvent.OnLogin)
+            }) {
+                Text("Login")
+            }
+            Box(modifier = Modifier.fillMaxSize()) {
+                TextButton(modifier = Modifier.align(Alignment.BottomCenter), onClick = {
                     localFocusManager.clearFocus()
-                    viewModel.onEvent(LoginEvent.OnLogin)
+                    viewModel.onEvent(LoginEvent.OnRegisterScreen)
                 }) {
-                    Text("Login")
-                }
-                Box(modifier = Modifier.fillMaxSize()) {
-                    TextButton(modifier = Modifier.align(Alignment.BottomCenter), onClick = {
-                        localFocusManager.clearFocus()
-                        viewModel.onEvent(LoginEvent.OnRegisterScreen)
-                    }) {
-                        Text("Or Register your Account here")
-                    }
+                    Text("Or Register your Account here")
                 }
             }
         }
     }
 }
+

--- a/budget-binder-multiplatform-app/src/jvmMain/kotlin/de/hsfl/budgetBinder/screens/login/LoginComponent.kt
+++ b/budget-binder-multiplatform-app/src/jvmMain/kotlin/de/hsfl/budgetBinder/screens/login/LoginComponent.kt
@@ -10,9 +10,6 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
-import de.hsfl.budgetBinder.BudgetBinderNavDrawer
-import de.hsfl.budgetBinder.BudgetBinderTopBar
-import de.hsfl.budgetBinder.TopBarMenuIcon
 import de.hsfl.budgetBinder.di
 import de.hsfl.budgetBinder.compose.dialog.ServerUrlDialog
 import de.hsfl.budgetBinder.compose.icon.AppIcon
@@ -26,12 +23,11 @@ import org.kodein.di.instance
 
 @Composable
 fun LoginComponent() {
-    val scope = rememberCoroutineScope()
     val viewModel: LoginViewModel by di.instance()
-    val emailTextState = viewModel.emailText.collectAsState(scope.coroutineContext)
-    val passwordTextState = viewModel.passwordText.collectAsState(scope.coroutineContext)
-    val serverUrlState = viewModel.serverUrlText.collectAsState(scope.coroutineContext)
-    val openDialog = viewModel.dialogState.collectAsState(scope.coroutineContext)
+    val emailTextState = viewModel.emailText.collectAsState()
+    val passwordTextState = viewModel.passwordText.collectAsState()
+    val serverUrlState = viewModel.serverUrlText.collectAsState()
+    val openDialog = viewModel.dialogState.collectAsState()
     val localFocusManager = LocalFocusManager.current
     val loadingState = remember { mutableStateOf(false) }
     val scaffoldState = rememberScaffoldState()


### PR DESCRIPTION
# Was wurde umgesetzt?
- Die TopAppBar wurde so angepasst, das bei register und login nicht durch den NavDrawer auf Inhalte zugegriffen werden können, welche nur bei erfolgreicher anmeldung zu sehen sein sollen.
- Screen wurde um `screenWeight` erweitert, um Animationen bei wechseln von ScreenStates zu implementieren (bis jetzt nur Category
